### PR TITLE
Swap to use of hybrid-array in place of generic constants

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,23 +54,6 @@ jobs:
     - name: Lint w/out Features
       run: cargo clippy --workspace --all-targets  --no-default-features --release
 
-    bench:
-      name: Check that benchmarks compile
-      runs-on: ubuntu-latest
-      steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Build u32 bench
-        env:
-          RUSTFLAGS: '--cfg curve25519_dalek_bits="32"'
-        run: cargo build --benches
-      - name: Build u64 bench
-        env:
-          RUSTFLAGS: '--cfg curve25519_dalek_bits="64"'
-        run: cargo build --benches
-      - name: Build default (host native) bench
-        run: cargo build --benches
-
   test-stable:
     name: Test 32/64 bit stable
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,47 +54,47 @@ jobs:
     - name: Lint w/out Features
       run: cargo clippy --workspace --all-targets  --no-default-features --release
 
-#     bench:
-#       name: Check that benchmarks compile
-#       runs-on: ubuntu-latest
-#       steps:
-#       - uses: actions/checkout@v4
-#       - uses: dtolnay/rust-toolchain@stable
-#       - name: Build u32 bench
-#         env:
-#           RUSTFLAGS: '--cfg curve25519_dalek_bits="32"'
-#         run: cargo build --benches
-#       - name: Build u64 bench
-#         env:
-#           RUSTFLAGS: '--cfg curve25519_dalek_bits="64"'
-#         run: cargo build --benches
-#       - name: Build default (host native) bench
-#         run: cargo build --benches
+    bench:
+      name: Check that benchmarks compile
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build u32 bench
+        env:
+          RUSTFLAGS: '--cfg curve25519_dalek_bits="32"'
+        run: cargo build --benches
+      - name: Build u64 bench
+        env:
+          RUSTFLAGS: '--cfg curve25519_dalek_bits="64"'
+        run: cargo build --benches
+      - name: Build default (host native) bench
+        run: cargo build --benches
 
-#   test-stable:
-#     name: Test 32/64 bit stable
-#     runs-on: ubuntu-latest
-#     strategy:
-#       matrix:
-#         include:
-#           # 32-bit target
-#           - target: i686-unknown-linux-gnu
-#             deps: >
-#               sudo dpkg --add-architecture i386;
-#               sudo touch /etc/apt/sources.list.d/i386-cross-compile-sources.list;
-#               echo "deb [arch=i386] http://ports.ubuntu.com/ focal universe\ndeb [arch=i386] http://ports.ubuntu.com/ focal-updates universe\n" | sudo tee -a /etc/apt/sources.list.d/i386-cross-compile-sources.list;
-#               sudo apt update && sudo apt install gcc-multilib libsqlite3-dev:i386
-#
-#           # 64-bit target
-#           - target: x86_64-unknown-linux-gnu
-#     steps:
-#     - uses: actions/checkout@v4
-#     - uses: dtolnay/rust-toolchain@stable
-#     - run: rustup target add ${{ matrix.target }}
-#     - run: ${{ matrix.deps }}
-#     - run: cargo test --target ${{ matrix.target }} --workspace --all-targets --all-features
-#   # - run: cargo test --target ${{ matrix.target }} --workspace --all-targets
-#   # - run: cargo test --target ${{ matrix.target }} --workspace --all-targets --no-default-features
+  test-stable:
+    name: Test 32/64 bit stable
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # 32-bit target
+          - target: i686-unknown-linux-gnu
+            deps: >
+              sudo dpkg --add-architecture i386;
+              sudo touch /etc/apt/sources.list.d/i386-cross-compile-sources.list;
+              echo "deb [arch=i386] http://ports.ubuntu.com/ focal universe\ndeb [arch=i386] http://ports.ubuntu.com/ focal-updates universe\n" | sudo tee -a /etc/apt/sources.list.d/i386-cross-compile-sources.list;
+              sudo apt update && sudo apt install gcc-multilib libsqlite3-dev:i386
+
+          # 64-bit target
+          - target: x86_64-unknown-linux-gnu
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - run: rustup target add ${{ matrix.target }}
+    - run: ${{ matrix.deps }}
+    - run: cargo test --target ${{ matrix.target }} --workspace --all-targets --all-features
+    - run: cargo test --target ${{ matrix.target }} --workspace --all-targets
+    - run: cargo test --target ${{ matrix.target }} --workspace --all-targets --no-default-features
 
   test-nightly:
     name: Test Nightly
@@ -104,20 +104,20 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo test --workspace --all-targets
 
-#   msrv:
-#     name: Check Crate against MSRV
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v3
-#     # Re-resolve Cargo.lock with minimal versions
-#     - uses: dtolnay/rust-toolchain@nightly
-#     - run: cargo update -Z minimal-versions
-#     # Now check that `cargo build` works with respect to the oldest possible
-#     # deps and the stated MSRV. 1.74 should work
-#     - uses: dtolnay/rust-toolchain@1.74.0
-#     - run: cargo test --workspace --all-targets --all-features
-#     # Also make sure the AVX2 build works
-#     - run: cargo build --target x86_64-unknown-linux-gnu
+  msrv:
+    name: Check Crate against MSRV
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    # Re-resolve Cargo.lock with minimal versions
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo update -Z minimal-versions
+    # Now check that `cargo build` works with respect to the oldest possible
+    # deps and the stated MSRV. 1.74 should work
+    - uses: dtolnay/rust-toolchain@1.74.0
+    - run: cargo test --workspace --all-targets --all-features
+    # Also make sure the AVX2 build works
+    - run: cargo build --target x86_64-unknown-linux-gnu
 
   build:
     name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,9 +96,13 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo update -Z minimal-versions
     # Now check that `cargo build` works with respect to the oldest possible
-    # deps and the stated MSRV. 1.74 should work
-    - uses: dtolnay/rust-toolchain@1.74.0
+    # deps and the stated MSRV. 1.81 should work
+    - uses: dtolnay/rust-toolchain@1.81
     - run: cargo test --workspace --all-targets --all-features
+      # # Now check that `cargo build` works with respect to the oldest possible
+      # # deps and the stated MSRV. 1.74 should work
+      # - uses: dtolnay/rust-toolchain@1.74.0
+      # - run: cargo test --workspace --all-targets --all-features
     # Also make sure the AVX2 build works
     - run: cargo build --target x86_64-unknown-linux-gnu
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 ml-kem = { version="0.2.1" }
-hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git" }
+hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }# git="https://github.com/RustCrypto/hybrid-array.git" }
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"
 lazy_static = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rustdoc-args = [
 ]
 
 [features]
-default=[]
+default=["deterministic"]
 deterministic = ["ml-kem/deterministic"]
 alloc = []
 
@@ -18,7 +18,8 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 ml-kem = { version="0.2.1" }
-hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }# git="https://github.com/RustCrypto/hybrid-array.git" }
+hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git", branch="master"} 
+# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"
 lazy_static = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rustdoc-args = [
 ]
 
 [features]
-default=["deterministic"]
+default=[]
 deterministic = ["ml-kem/deterministic"]
 alloc = []
 
@@ -18,12 +18,11 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 ml-kem = { version="0.2.1" }
-hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git", branch="master"} 
-# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }
+# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git", branch="master"} 
+hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"
 lazy_static = "1.5.0"
-typenum = "1.17.0"
 
 # HKDF RNG
 digest = "0.10.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 ml-kem = { version="0.2.1" }
-hybrid-array = "0.2.0-rc.8"
+hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git" }
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"
 lazy_static = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,17 @@
 name = "kemeleon"
 version = "0.1.0"
 edition = "2021"
+description = """
+Kemeleon encoding algorithms for obfuscating ML-KEM handshake elements.
+"""
+authors = ["jmwample"]
+license = "MIT OR Apache-2.0"
+documentation = "https://docs.rs/kemeleon"
+repository = "https://github.com/jmwample/kemeleon"
+categories = ["no-std", "cryptography"]
+keywords = ["ML-KEM", "Kemeleon", "cryptography"]
+readme = "README.md"
+rust-version = "1.81"
 
 [package.metadata.docs.rs]
 rustdoc-args = [
@@ -18,8 +29,9 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 ml-kem = { version="0.2.1" }
-# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git", branch="master"} 
-hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }
+# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"]} 
+# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }
+hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git", branch="master"} 
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"
 lazy_static = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rustdoc-args = [
 ]
 
 [features]
-default=["deterministic"]
+default=[]
 deterministic = ["ml-kem/deterministic"]
 alloc = []
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ The implementation contained in this crate has never been independently audited!
 <h4><b>USE AT YOUR OWN RISK!</b></h4>
 </center>
 
+
+🚧  UNDER CONSTRUCTION  🚧
+This library is in a devloping (non-stable) condition, meaning that things will likely change. This includes
+API, interface, algorithms, etc. -- Feedback is welcome, but we do not guarantee support for any features /
+interface as currently implemented.
+
 ## Usage
 
 ```rust ignore
@@ -94,16 +100,22 @@ Core features
 - [x] Modify implementation to be `no-std` compatible
   - [x] Swap from custom error to &str error just for simplicity (`core::error::Error` is too new)
 - [x] GH actions for testing, building, linting, etc.
-- [ ] Use [`generic_array`](https://docs.rs/generic-array/latest/generic_array/) for
+- [x] Use [`hybrid-array`](https://docs.rs/hybrid-array/0.2.0-rc.9/hybrid_array/) for
   all type based generics requiring sized arrays
-  - [ ] Move const generics (`#![feature(generics_const_exprs)]`) to its own branch
+  - [x] Move const generics (`#![feature(generics_const_exprs)]`) to its own branch
     - const generics are an unstable feature, even though this is a very simple
       application of the feature it is bad practice to ask people use it in its current state.
-  - [ ] CI tests/builds for stable releases (const generics only work on nightly)
+  - [x] CI tests/builds for stable releases (const generics only work on nightly)
 - [ ] Nist vectors Integration tests
 
-Cleanup
+Cleanup -> Release 0.1.0-alpha
 
 - [ ] Polish public interface and docs for first release
 - [ ] Github actions release workflow
 
+Heading to Release 0.1.1-alpha
+
+- [ ] work up PR(s) for [ml-kem](https://docs.rs/ml-kem/latest/ml_kem/)
+  - [ ] expose internal things under a `dev` feature
+- [ ] remove as much repeated functionality as possible
+- [ ] revisit secure deterministic random byte generation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue" alt="License: MIT/Apache 2.0">
   </a>
   <a href="https://github.com/jmwample/kemeleon#minimum-supported-rust-version-msrv">
-    <img src="https://img.shields.io/badge/MSRV-1.74+-blue.svg" alt="MSRV 1.74">
+    <img src="https://img.shields.io/badge/MSRV-1.81+-blue.svg" alt="MSRV 1.81">
   </a>
 </p>
 
@@ -74,17 +74,17 @@ all values are 12 bits, but always less than 3329.
 
 ## Minimum Supported Rust Version (MSRV)
 
-The Minimum Supported Rust Versions (MSRV) for this crate is **Rust 1.74**
-(currently forced by the [`ml_kem`](https://docs.rs/ml-kem/latest/ml_kem/) dependency).
+The Minimum Supported Rust Versions (MSRV) for this crate is **Rust 1.81**
+(currently forced by the [`hybrid-array`](https://docs.rs/hybrid-array) dependency).
 This minumum version will be ensured by the test and build steps in the CI pipeline.
 
 Going forward, the MSRV can be changed at any time, but it will be done with
 a minor version bump. We will not increase MSRV on PATCH releases, though
 downstream dependencies might.
 
-We won't increase MSRV just because we can: we'll only do so when we have a
-reason. (We don't guarantee that you'll agree with our reasoning; only that
-it will exist.)
+Once this crate reaches a stable state we won't increase MSRV just because we
+can: we'll only do so when we have a reason. (We don't guarantee that you'll agree
+with our reasoning; only that it will exist.)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Core features
 - [x] Implement complete Encapsulation Key encoding / decoding
 - [x] Implement and test ciphertext encoding / decoding
 - [x] Pass on public docs
-- [x] Switch from using [`std::io::Error`] to a locally defined error type.
+- [x] Switch from using `std::io::Error` to a locally defined error type.
 - [x] Ciphertext encoding determinism using hkdf, hmac-drbg, or something similar
 - [x] Modify implementation to be `no-std` compatible
   - [x] Swap from custom error to &str error just for simplicity (`core::error::Error` is too new)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
   <a href="https://doc.rust-lang.org/1.6.0/complement-project-faq.html#why-dual-mitasl2-license">
     <img src="https://img.shields.io/badge/license-MIT%2FApache--2.0-blue" alt="License: MIT/Apache 2.0">
   </a>
+  <a href="https://github.com/jmwample/kemeleon#minimum-supported-rust-version-msrv">
+    <img src="https://img.shields.io/badge/MSRV-1.74+-blue.svg" alt="MSRV 1.74">
+  </a>
 </p>
 
 This crates implements the kemeleon algorithms for secure obfuscation of ML-KEM

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -11,7 +11,9 @@
 //! properly.
 //!
 
-use crate::{Barr8, EncodingSize, FieldElement, FipsEncodingSize, NttArray, ARR_LEN, RHO_LEN};
+use hybrid_array::{typenum::Unsigned, Array};
+
+use crate::{ByteArray, EncodingSize, FieldElement, FipsByteArraySize, NttArray, ARR_LEN, RHO_LEN};
 
 /// This is a helper function for computing a conversion of number of values to
 /// number of bytes when encoding values using `d` bits each.
@@ -45,14 +47,13 @@ fn gcd(x: usize, y: usize) -> usize {
 // Algorithm 4 ByteEncode_d(F)
 //
 // Note: This algorithm performs compression as well as encoding.
-pub(crate) fn byte_encode<D, const USIZE: usize>(
-    ntt_vals: &NttArray<{ D::K }>,
-    mut dst: impl AsMut<[u8]>,
-) where
+pub(crate) fn byte_encode<D: FipsByteArraySize>(ntt_vals: &NttArray<D>, mut dst: impl AsMut<[u8]>)
+where
     D: EncodingSize,
 {
+    let val_width: usize = D::USIZE::USIZE;
     let bytes = dst.as_mut();
-    let idx = USIZE * D::K * 32; // (32 = 256 / 8)
+    let idx = val_width * D::K::USIZE * 32; // (32 = 256 / 8)
 
     // TODO should I remove this length check or convert it to a result?
     assert_eq!(
@@ -60,17 +61,17 @@ pub(crate) fn byte_encode<D, const USIZE: usize>(
         idx,
         "incorrect dst len {} != {idx}  K:{}",
         bytes.len(),
-        D::K
+        D::K::USIZE,
     );
 
-    let (val_step, byte_step) = get_relative_steps(USIZE);
+    let (val_step, byte_step) = get_relative_steps(val_width);
 
     let vc = ntt_vals.as_flattened().chunks(val_step);
     let bc = bytes[..idx].chunks_mut(byte_step);
     for (v, b) in vc.zip(bc) {
         let mut x = 0u128;
         for (j, vj) in v.iter().enumerate() {
-            x |= u128::from(*vj) << (USIZE * j);
+            x |= u128::from(*vj) << (val_width * j);
         }
 
         let xb = x.to_le_bytes();
@@ -81,13 +82,13 @@ pub(crate) fn byte_encode<D, const USIZE: usize>(
 // Algorithm 5 ByteDecode_d(F)
 //
 // Note: This function performs decompression as well as decoding.
-pub(crate) fn byte_decode<D: EncodingSize, const USIZE: usize>(
-    bytes: impl AsRef<[u8]>,
-) -> NttArray<{ D::K }> {
-    let (val_step, byte_step) = get_relative_steps(USIZE);
-    let mask = (1 << USIZE) - 1;
+pub(crate) fn byte_decode<D: EncodingSize>(bytes: impl AsRef<[u8]>) -> NttArray<D> {
+    let val_width: usize = D::USIZE::USIZE;
+    let (val_step, byte_step) = get_relative_steps(val_width);
+    let mask = (1 << val_width) - 1;
 
-    let mut vals = [[0u16; ARR_LEN]; D::K];
+    let mut vals: NttArray<D> = Array::from_fn(|_| Array::from_fn(|_| 0_u16));
+    // let mut vals = [[0u16; ARR_LEN::USIZE]; D::K::USIZE];
 
     let vc = vals.as_flattened_mut().chunks_mut(val_step);
     let bc = bytes.as_ref().chunks(byte_step);
@@ -98,10 +99,10 @@ pub(crate) fn byte_decode<D: EncodingSize, const USIZE: usize>(
         let x = u128::from_le_bytes(xb);
         for (j, v_out) in v.iter_mut().enumerate() {
             // TODO: is the truncate implementation really necessary?
-            let val: u16 = (x >> (USIZE * j)).truncate();
+            let val: u16 = (x >> (val_width * j)).truncate();
             *v_out = val & mask;
 
-            if USIZE == 12 {
+            if val_width == 12 {
                 *v_out %= FieldElement::Q;
             }
         }
@@ -138,37 +139,38 @@ define_truncate!(u128, u8);
 // FIPs spec EncapsulationKey Encoding
 // ========================================================================== //
 
-pub(crate) fn ek_encode<D>(
+pub(crate) fn ek_encode<D: FipsByteArraySize>(
     rho: &[u8; 32],
-    ntt_vals: &NttArray<{ D::K }>,
-) -> Barr8<{ D::FIPS_ENCODED_SIZE }>
+    ntt_vals: &NttArray<D>,
+) -> ByteArray<D::ENCODED_EK_SIZE>
 where
     D: EncodingSize,
 {
-    let mut bytes = [0u8; D::FIPS_ENCODED_SIZE];
-    let idx = D::FIPS_ENCODED_SIZE - RHO_LEN;
+    // let mut bytes = Array::n 0u8; D::ENCODED_EK_SIZE];
+    let mut bytes: ByteArray<D::ENCODED_EK_SIZE> = Array::from_fn(|_| 0u8);
+    let idx = D::ENCODED_EK_SIZE::USIZE - RHO_LEN::USIZE;
 
-    byte_encode::<D, { D::USIZE }>(ntt_vals, &mut bytes[..idx]);
+    byte_encode::<D>(ntt_vals, &mut bytes[..idx]);
     bytes[idx..].copy_from_slice(&rho[..]);
 
     bytes
 }
 
-pub(crate) fn ek_decode<D>(bytes: impl AsRef<[u8]>) -> ([u8; 32], NttArray<{ D::K }>)
+pub(crate) fn ek_decode<D: FipsByteArraySize>(bytes: impl AsRef<[u8]>) -> ([u8; 32], NttArray<D>)
 where
     D: EncodingSize,
 {
     //TODO: Lenth check on input for safety?
     assert!(
-        bytes.as_ref().len() > (D::FIPS_ENCODED_SIZE - RHO_LEN),
+        bytes.as_ref().len() > (D::ENCODED_EK_SIZE::USIZE - RHO_LEN::USIZE),
         "incorrect src len for K:{}",
-        D::K
+        D::K::USIZE
     );
 
-    let idx = bytes.as_ref().len() - RHO_LEN;
-    let vals = byte_decode::<D, { D::USIZE }>(&bytes.as_ref()[..idx]);
+    let idx = bytes.as_ref().len() - RHO_LEN::USIZE;
+    let vals = byte_decode::<D>(&bytes.as_ref()[..idx]);
 
-    let mut rho = [0u8; RHO_LEN];
+    let mut rho = [0u8; RHO_LEN::USIZE];
     rho.copy_from_slice(&bytes.as_ref()[idx..]);
 
     (rho, vals)
@@ -178,11 +180,11 @@ where
 // FIPs spec Ciphertext Utilities
 // ========================================================================== //
 
-pub(crate) fn ct_vdecompress(dv: usize, bytes: &[u8]) -> [u16; ARR_LEN] {
+pub(crate) fn ct_vdecompress(dv: usize, bytes: &[u8]) -> [u16; ARR_LEN::USIZE] {
     let (val_step, byte_step) = get_relative_steps(dv);
     let mask = (1 << dv) - 1;
 
-    let mut vals = [0u16; ARR_LEN];
+    let mut vals = [0u16; ARR_LEN::USIZE];
 
     let vc = vals.chunks_mut(val_step);
     let bc = bytes.as_ref().chunks(byte_step);
@@ -206,14 +208,14 @@ pub(crate) fn ct_vdecompress(dv: usize, bytes: &[u8]) -> [u16; ARR_LEN] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{EncodingSize, RHO_LEN};
+    use crate::RHO_LEN;
     use hex_literal::hex;
 
     use ml_kem::{Encoded, EncodedSizeUser, KemCore, MlKem1024, MlKem512, MlKem768};
 
     fn fips_encode_trial<D>()
     where
-        D: KemCore + EncodingSize,
+        D: KemCore + FipsByteArraySize,
     {
         let mut rng = rand::thread_rng();
         let (_, ek) = D::generate(&mut rng);
@@ -225,14 +227,14 @@ mod tests {
         let bytes_out = ek_encode::<D>(&rho, &ntt);
         // check that the byte representation of rho matches.
         assert_eq!(
-            hex::encode(&bytes_in[..RHO_LEN]),
-            hex::encode(&bytes_out[..RHO_LEN]),
+            hex::encode(&bytes_in[..RHO_LEN::USIZE]),
+            hex::encode(&bytes_out[..RHO_LEN::USIZE]),
             "rho values do not match"
         );
         // check that the byte representation of the polynomials matches.
         assert_eq!(
-            hex::encode(&bytes_in[RHO_LEN..]),
-            hex::encode(&bytes_out[RHO_LEN..]),
+            hex::encode(&bytes_in[RHO_LEN::USIZE..]),
+            hex::encode(&bytes_out[RHO_LEN::USIZE..]),
             "polynomials do not match"
         );
 

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -144,7 +144,6 @@ pub(crate) fn ek_encode<D>(
 ) -> Barr8<{ D::FIPS_ENCODED_SIZE }>
 where
     D: EncodingSize,
-    [(); D::USIZE]:,
 {
     let mut bytes = [0u8; D::FIPS_ENCODED_SIZE];
     let idx = D::FIPS_ENCODED_SIZE - RHO_LEN;
@@ -158,7 +157,6 @@ where
 pub(crate) fn ek_decode<D>(bytes: impl AsRef<[u8]>) -> ([u8; 32], NttArray<{ D::K }>)
 where
     D: EncodingSize,
-    [(); D::USIZE]:,
 {
     //TODO: Lenth check on input for safety?
     assert!(
@@ -208,7 +206,7 @@ pub(crate) fn ct_vdecompress(dv: usize, bytes: &[u8]) -> [u16; ARR_LEN] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{EncodingSize, FipsEncodingSize, RHO_LEN};
+    use crate::{EncodingSize, RHO_LEN};
     use hex_literal::hex;
 
     use ml_kem::{Encoded, EncodedSizeUser, KemCore, MlKem1024, MlKem512, MlKem768};
@@ -216,9 +214,6 @@ mod tests {
     fn fips_encode_trial<D>()
     where
         D: KemCore + EncodingSize,
-        [(); D::USIZE]:,
-        [(); <D as EncodingSize>::K]:,
-        [(); <D as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
     {
         let mut rng = rand::thread_rng();
         let (_, ek) = D::generate(&mut rng);

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -141,12 +141,9 @@ define_truncate!(u128, u8);
 // FIPs spec EncapsulationKey Encoding
 // ========================================================================== //
 
-pub(crate) fn ek_encode<D: FipsByteArraySize>(
-    rho: &[u8; 32],
-    ntt_vals: &NttArray<D>,
-) -> ByteArray<D::ENCODED_EK_SIZE>
+pub(crate) fn ek_encode<D>(rho: &[u8; 32], ntt_vals: &NttArray<D>) -> ByteArray<D::ENCODED_EK_SIZE>
 where
-    D: EncodingSize,
+    D: EncodingSize + FipsByteArraySize,
 {
     // let mut bytes = Array::n 0u8; D::ENCODED_EK_SIZE];
     let mut bytes: ByteArray<D::ENCODED_EK_SIZE> = Array::from_fn(|_| 0u8);
@@ -158,9 +155,9 @@ where
     bytes
 }
 
-pub(crate) fn ek_decode<D: FipsByteArraySize>(bytes: impl AsRef<[u8]>) -> ([u8; 32], NttArray<D>)
+pub(crate) fn ek_decode<D>(bytes: impl AsRef<[u8]>) -> ([u8; 32], NttArray<D>)
 where
-    D: EncodingSize,
+    D: EncodingSize + FipsByteArraySize,
 {
     //TODO: Length check on input for safety?
     assert!(

--- a/src/kemeleon.rs
+++ b/src/kemeleon.rs
@@ -12,9 +12,9 @@ use crate::{EncodeError, EncodingSize, FieldElement};
 
 use core::cmp::min;
 
+use hybrid_array::typenum::Unsigned;
 use ml_kem::KemCore;
 use num_bigint::BigUint;
-use hybrid_array::typenum::Unsigned;
 
 mod ciphertext;
 mod encapsulation_key;

--- a/src/kemeleon.rs
+++ b/src/kemeleon.rs
@@ -49,7 +49,6 @@ pub(crate) fn vector_encode<P>(
 ) -> Result<bool, EncodeError>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
 {
     let dst = c.as_mut();
     if dst.len() < P::T_HAT_LEN {
@@ -82,8 +81,6 @@ pub(crate) fn vector_decode<P>(
 ) -> Result<(), EncodeError>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
 {
     if c.as_ref().len() < <P as EncodingSize>::T_HAT_LEN {
         return Err(EncodeError::invalid_ctxt_len(c.as_ref().len()));

--- a/src/kemeleon.rs
+++ b/src/kemeleon.rs
@@ -6,12 +6,15 @@ pub use crate::mlkem::KDecapsulationKey as DecapsulationKey;
 /// An `EncapsulationKey` provides the ability to encapsulate a shared key so that it can
 /// only be decapsulated by the holder of the corresponding decapsulation key.
 pub use crate::mlkem::KEncapsulationKey as EncapsulationKey;
-use crate::{EncodeError, EncodingSize, FieldElement, FipsEncodingSize};
+use crate::FipsByteArraySize;
+use crate::KemeleonByteArraySize;
+use crate::{EncodeError, EncodingSize, FieldElement};
 
 use core::cmp::min;
 
 use ml_kem::KemCore;
 use num_bigint::BigUint;
+use hybrid_array::typenum::Unsigned;
 
 mod ciphertext;
 mod encapsulation_key;
@@ -48,11 +51,11 @@ pub(crate) fn vector_encode<P>(
     mut c: impl AsMut<[u8]>,
 ) -> Result<bool, EncodeError>
 where
-    P: KemCore + EncodingSize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
     let dst = c.as_mut();
-    if dst.len() < P::T_HAT_LEN {
-        return Err(EncodeError::bad_dst_array(P::T_HAT_LEN, dst.len()));
+    if dst.len() < P::T_HAT_LEN::USIZE {
+        return Err(EncodeError::bad_dst_array(P::T_HAT_LEN::USIZE, dst.len()));
     }
 
     let mut out = BigUint::ZERO;
@@ -68,11 +71,11 @@ where
 
     // avoid out-of-bounds access if high order byte is 0x00
     let b = out.to_bytes_le();
-    let l = min(P::T_HAT_LEN, b.len());
+    let l = min(P::T_HAT_LEN::USIZE, b.len());
     dst[..l].copy_from_slice(&b[..l]);
 
     // Sample failure if High order bit is set.
-    Ok(dst[P::T_HAT_LEN - 1] & P::MSB_BITMASK == 0)
+    Ok(dst[P::T_HAT_LEN::USIZE - 1] & P::MSB_BITMASK == 0)
 }
 
 pub(crate) fn vector_decode<P>(
@@ -82,7 +85,7 @@ pub(crate) fn vector_decode<P>(
 where
     P: KemCore + EncodingSize,
 {
-    if c.as_ref().len() < <P as EncodingSize>::T_HAT_LEN {
+    if c.as_ref().len() < P::T_HAT_LEN::USIZE {
         return Err(EncodeError::invalid_ctxt_len(c.as_ref().len()));
     }
 

--- a/src/kemeleon/ciphertext.rs
+++ b/src/kemeleon/ciphertext.rs
@@ -25,11 +25,6 @@ pub use crate::mlkem::KEncodedCiphertext as EncodedCiphertext;
 impl<P> Encode for EncodedCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
 {
     /// Encoded Cuphertext Type
     type ET = Barr8<{ P::ENCODED_CT_SIZE }>;
@@ -59,11 +54,6 @@ const HKDF_INFO: [u8; 40] = *b"kemeleon ct hkdf random number generator";
 impl<P> Ciphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
 {
     pub(crate) fn new(
         fips_ct: &ml_kem::Ciphertext<P>,
@@ -122,11 +112,7 @@ where
         Ok(success)
     }
 
-    pub(crate) fn decode(c: impl AsRef<[u8]>) -> Result<Self, EncodeError>
-    where
-        [(); P::FIPS_ENCODED_USIZE]:,
-        [(); P::FIPS_ENCODED_CT_SIZE]:,
-    {
+    pub(crate) fn decode(c: impl AsRef<[u8]>) -> Result<Self, EncodeError> {
         let mut ct_bytes = [0u8; P::ENCODED_CT_SIZE];
         ct_bytes[..].copy_from_slice(&c.as_ref()[..P::ENCODED_CT_SIZE]);
         let (c1, c2) = split_ct::<P>(&ct_bytes);
@@ -205,7 +191,6 @@ where
 fn concat_ct<P>(u: &[u8], v: &[u8]) -> [u8; P::ENCODED_CT_SIZE]
 where
     P: EncodingSize,
-    [(); P::ENCODED_CT_SIZE]:,
 {
     let mut out = [0u8; P::ENCODED_CT_SIZE];
     out[..P::ENCODED_USIZE].copy_from_slice(&u[..P::ENCODED_USIZE]);
@@ -224,14 +209,6 @@ mod test {
     fn encode_decode_trial<P>(desc: &str)
     where
         P: ml_kem::KemCore + EncodingSize,
-        [(); P::K]:,
-        [(); P::DU]:,
-        [(); P::USIZE]:,
-        [(); P::ENCODED_SIZE]:,
-        [(); P::ENCODED_CT_SIZE]:,
-        [(); P::FIPS_ENCODED_SIZE]:,
-        [(); P::FIPS_ENCODED_USIZE]:,
-        [(); P::FIPS_ENCODED_CT_SIZE]:,
     {
         let mut rng = rand::thread_rng();
         // use Kemx::generate so that we don't have to worry about the

--- a/src/kemeleon/ciphertext.rs
+++ b/src/kemeleon/ciphertext.rs
@@ -1,6 +1,7 @@
 use super::{vector_decode, vector_encode, Encode};
 use crate::{
-    fips, ByteArr, ByteArray, EncodeError, FieldElement, FipsByteArraySize, FipsEncodingSize, KemeleonByteArraySize, KemeleonEncodingSize, Ntt
+    fips, ByteArr, ByteArray, EncodeError, FieldElement, FipsByteArraySize, FipsEncodingSize,
+    KemeleonByteArraySize, KemeleonEncodingSize, Ntt,
 };
 
 use hybrid_array::ArraySize;
@@ -188,12 +189,9 @@ fn split_ct<P>(b: &[u8]) -> (&[u8], &[u8])
 where
     P: KemeleonByteArraySize,
 {
-        let ct_len = <P as KemeleonByteArraySize>::ENCODED_CT_SIZE::USIZE;
-        let u_len = <P as KemeleonEncodingSize>::ENCODED_USIZE::USIZE;
-    (
-        &(b[..u_len]),
-        &(b[u_len..ct_len]),
-    )
+    let ct_len = <P as KemeleonByteArraySize>::ENCODED_CT_SIZE::USIZE;
+    let u_len = <P as KemeleonEncodingSize>::ENCODED_USIZE::USIZE;
+    (&(b[..u_len]), &(b[u_len..ct_len]))
 }
 
 fn concat_ct<P>(u: &[u8], v: &[u8]) -> ByteArray<P::ENCODED_CT_SIZE>
@@ -233,8 +231,8 @@ mod test {
         // encapsulate a secret using the kemeleon Encapsulation key
         let (mut ct, mut k_send) = ek.key.encapsulate(&mut rng).unwrap();
         // attempt to encode the ciphertext to kemeleon representation
-        let (mut encodable, mut kemeleon_ct) =
-            KCiphertext::<MlKem512>::new_from_rng(&ct, &mut rng).expect("failed to make new ciphertext");
+        let (mut encodable, mut kemeleon_ct) = KCiphertext::<MlKem512>::new_from_rng(&ct, &mut rng)
+            .expect("failed to make new ciphertext");
 
         let mut i = 0;
         while !encodable && i < MAX_RETRIES {

--- a/src/kemeleon/ciphertext.rs
+++ b/src/kemeleon/ciphertext.rs
@@ -98,7 +98,7 @@ where
     fn encode<R: RngCore + CryptoRng>(&mut self, rng: &mut R) -> Result<bool, EncodeError> {
         // split the u and v elements
         let (c1, c2) = split_fips_ct::<P>(&self.fips);
-        let mut r1 = fips::byte_decode::<P>(&c1);
+        let mut r1 = fips::byte_decode::<P, P::DU>(&c1);
 
         // re-add randomness to the u elements
         r1.as_flattened_mut().iter_mut().decompress::<P::DU>();
@@ -133,7 +133,7 @@ where
 
         // convert back to fips encoding of the U values
         let mut fips_ct = ByteArr::zero::<<P as FipsByteArraySize>::ENCODED_CT_SIZE>();
-        fips::byte_encode::<P>(&values, &mut fips_ct[..fips_u_len]);
+        fips::byte_encode::<P, P::DU>(&values, &mut fips_ct[..fips_u_len]);
 
         // ml_kem::Ciphertext = c1 || c2
         fips_ct[fips_u_len..].copy_from_slice(c2);

--- a/src/kemeleon/ciphertext.rs
+++ b/src/kemeleon/ciphertext.rs
@@ -231,8 +231,8 @@ mod test {
         // encapsulate a secret using the kemeleon Encapsulation key
         let (mut ct, mut k_send) = ek.key.encapsulate(&mut rng).unwrap();
         // attempt to encode the ciphertext to kemeleon representation
-        let (mut encodable, mut kemeleon_ct) = KCiphertext::<MlKem512>::new_from_rng(&ct, &mut rng)
-            .expect("failed to make new ciphertext");
+        let (mut encodable, mut kemeleon_ct) =
+            KCiphertext::<P>::new_from_rng(&ct, &mut rng).expect("failed to make new ciphertext");
 
         let mut i = 0;
         while !encodable && i < MAX_RETRIES {
@@ -257,7 +257,7 @@ mod test {
         let ct_bytes_recv = KEncodedCiphertext::try_from_bytes(ct_bytes)
             .unwrap_or_else(|e| panic!("{desc} failed to parse KEncodedCiphertext {e}"));
 
-        let ct_recv = KCiphertext::decode(&ct_bytes_recv)
+        let ct_recv = KCiphertext::<P>::decode(&ct_bytes_recv)
             .unwrap_or_else(|e| panic!("{desc}: failed decode {e}"));
         assert_eq!(ct_recv.fips, ct, "{desc}: fips ciphertexts don't match");
 

--- a/src/kemeleon/ciphertext/compress.rs
+++ b/src/kemeleon/ciphertext/compress.rs
@@ -8,7 +8,7 @@ use crate::{fips::Truncate, FieldElement};
 
 use core::slice::IterMut;
 
-pub(crate) struct Du<const USIZE: usize> {}
+use hybrid_array::ArraySize;
 
 pub(crate) trait CompressionFactor {
     const USIZE: usize;
@@ -19,8 +19,8 @@ pub(crate) trait CompressionFactor {
     const Q_HALF: u64 = (FieldElement::Q64 + 1) >> 1;
 }
 
-impl<const USIZE: usize> CompressionFactor for Du<{ USIZE }> {
-    const USIZE: usize = USIZE;
+impl<D: ArraySize> CompressionFactor for D {
+    const USIZE: usize = Self::USIZE;
     const POW2_HALF: u32 = 1 << (Self::USIZE - 1);
     const MASK: u16 = ((1_u16) << Self::USIZE) - 1;
     const DIV_SHIFT: usize = 34;
@@ -101,6 +101,7 @@ impl<'a> Compress for IterMut<'a, u16> {
 pub(crate) mod test {
     use super::*;
     use num_rational::Ratio;
+    use hybrid_array::typenum::{U1, U4, U5, U6, U10, U11, U12};
 
     fn rational_compress<D: CompressionFactor>(input: u16) -> u16 {
         let fraction = Ratio::new(u32::from(input) * (1 << D::USIZE), FieldElement::Q32);
@@ -179,21 +180,21 @@ pub(crate) mod test {
 
     #[test]
     fn decompress_compress() {
-        compress_decompress_properties::<Du<1>>();
-        compress_decompress_properties::<Du<4>>();
-        compress_decompress_properties::<Du<5>>();
-        compress_decompress_properties::<Du<6>>();
-        compress_decompress_properties::<Du<10>>();
-        compress_decompress_properties::<Du<11>>();
+        compress_decompress_properties::<U1>();
+        compress_decompress_properties::<U4>();
+        compress_decompress_properties::<U5>();
+        compress_decompress_properties::<U6>();
+        compress_decompress_properties::<U10>();
+        compress_decompress_properties::<U11>();
         // preservation under decompression first only holds for d < 12
-        compression_decompression_inequality::<Du<12>>();
+        compression_decompression_inequality::<U12>();
 
-        compress_decompress_KATs::<Du<1>>();
-        compress_decompress_KATs::<Du<4>>();
-        compress_decompress_KATs::<Du<5>>();
-        compress_decompress_KATs::<Du<6>>();
-        compress_decompress_KATs::<Du<10>>();
-        compress_decompress_KATs::<Du<11>>();
-        compress_decompress_KATs::<Du<12>>();
+        compress_decompress_KATs::<U1>();
+        compress_decompress_KATs::<U4>();
+        compress_decompress_KATs::<U5>();
+        compress_decompress_KATs::<U6>();
+        compress_decompress_KATs::<U10>();
+        compress_decompress_KATs::<U11>();
+        compress_decompress_KATs::<U12>();
     }
 }

--- a/src/kemeleon/ciphertext/compress.rs
+++ b/src/kemeleon/ciphertext/compress.rs
@@ -100,8 +100,8 @@ impl<'a> Compress for IterMut<'a, u16> {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
+    use hybrid_array::typenum::{U1, U10, U11, U12, U4, U5, U6};
     use num_rational::Ratio;
-    use hybrid_array::typenum::{U1, U4, U5, U6, U10, U11, U12};
 
     fn rational_compress<D: CompressionFactor>(input: u16) -> u16 {
         let fraction = Ratio::new(u32::from(input) * (1 << D::USIZE), FieldElement::Q32);

--- a/src/kemeleon/ciphertext/hkdf_rng.rs
+++ b/src/kemeleon/ciphertext/hkdf_rng.rs
@@ -36,6 +36,7 @@ where
 {
     private_buf: [u8; MAX_FILL],
     count: usize,
+    _digest: core::marker::PhantomData<D>,
 }
 
 #[allow(dead_code)]
@@ -64,6 +65,7 @@ where
         Self {
             private_buf: buf,
             count: 0,
+            _digest: core::marker::PhantomData{},
         }
     }
 

--- a/src/kemeleon/ciphertext/hkdf_rng.rs
+++ b/src/kemeleon/ciphertext/hkdf_rng.rs
@@ -65,7 +65,7 @@ where
         Self {
             private_buf: buf,
             count: 0,
-            _digest: core::marker::PhantomData{},
+            _digest: core::marker::PhantomData {},
         }
     }
 

--- a/src/kemeleon/ciphertext/precomputed.rs
+++ b/src/kemeleon/ciphertext/precomputed.rs
@@ -3098,6 +3098,7 @@ mod test {
     use crate::kemeleon::ciphertext::compress::*;
     use crate::{EncodingSize, FieldElement};
 
+    use hybrid_array::ArraySize;
     use ml_kem::{MlKem1024, MlKem512, MlKem768};
 
     use super::*;
@@ -3128,16 +3129,12 @@ mod test {
         eq_set_completeness_test("du:11, [MlKem1024]", &EQ_SET_11[..]);
     }
 
-    fn eq_sets_match_test<D>(desc: &str)
-    where
-        D: EncodingSize,
-        [(); D::DU]:,
-    {
+    fn eq_sets_match_test<D: EncodingSize>(desc: &str) {
         for v in 0..FieldElement::Q {
             let mut compressed_v = v;
-            compressed_v.compress::<Du<{ D::DU }>>();
+            compressed_v.compress::<D::DU>();
 
-            let eq_set = get_eq_set::<{ D::DU }>(compressed_v);
+            let eq_set = get_eq_set::<D::DU>(compressed_v);
             assert!(
                 eq_set.to_vec().contains(&v),
                 "{desc}: {v} maps to incorrect set {eq_set:?}",

--- a/src/kemeleon/ciphertext/precomputed.rs
+++ b/src/kemeleon/ciphertext/precomputed.rs
@@ -1,12 +1,13 @@
 //! TODO: Document Use of Precomputed for re-randomizing U values
+use hybrid_array::ArraySize;
 use lazy_static::lazy_static;
 
-pub(crate) fn get_eq_set<const USIZE: usize>(u_i: u16) -> &'static [u16] {
-    if u_i > 2_u16.pow(USIZE as u32) {
+pub(crate) fn get_eq_set<Du: ArraySize>(u_i: u16) -> &'static [u16] {
+    if u_i > 2_u16.pow(Du::USIZE as u32) {
         return &[];
     }
 
-    match USIZE {
+    match Du::USIZE {
         10 => EQ_SET_10[u_i as usize],
         11 => EQ_SET_11[u_i as usize],
         _ => &[],
@@ -3095,13 +3096,11 @@ lazy_static! {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::kemeleon::ciphertext::compress::*;
     use crate::{EncodingSize, FieldElement};
 
-    use hybrid_array::ArraySize;
     use ml_kem::{MlKem1024, MlKem512, MlKem768};
-
-    use super::*;
 
     fn eq_set_completeness_test(desc: &str, eq_set: &[&[u16]]) {
         let mut s = Vec::new();

--- a/src/kemeleon/encapsulation_key.rs
+++ b/src/kemeleon/encapsulation_key.rs
@@ -63,6 +63,8 @@ where
     }
 }
 
+const R_LEN: usize = RHO_LEN::USIZE;
+
 impl<P> EncapsulationKey<P>
 where
     P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
@@ -70,7 +72,6 @@ where
     fn decode_priv(c: impl AsRef<[u8]>) -> Result<Self, EncodeError> {
         let ek_len = <P as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE;
         let t_hat_len = <P as EncodingSize>::T_HAT_LEN::USIZE;
-        const R_LEN: usize = RHO_LEN::USIZE;
 
         if c.as_ref().len() < ek_len {
             return Err(EncodeError::invalid_ek_len(c.as_ref().len()));

--- a/src/kemeleon/encapsulation_key.rs
+++ b/src/kemeleon/encapsulation_key.rs
@@ -1,7 +1,8 @@
 use super::{vector_decode, vector_encode, EncapsulationKey, Encodable, Encode};
-use crate::{fips, Barr8, EncodeError, EncodingSize, FipsEncodingSize, ARR_LEN, RHO_LEN};
+use crate::{fips, ByteArray, EncodeError, EncodingSize, FipsByteArraySize, KemeleonByteArraySize, Ntt, RHO_LEN};
 
 use ml_kem::{EncodedSizeUser, KemCore};
+use hybrid_array::typenum::Unsigned;
 
 // ========================================================================== //
 // Encapsulation Key
@@ -9,9 +10,9 @@ use ml_kem::{EncodedSizeUser, KemCore};
 
 impl<P> Encode for EncapsulationKey<P>
 where
-    P: KemCore + EncodingSize + FipsEncodingSize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
-    type ET = Barr8<{ <P as EncodingSize>::ENCODED_SIZE }>;
+    type ET = ByteArray<<P as KemeleonByteArraySize>::ENCODED_EK_SIZE>;
     type Error = EncodeError;
 
     /// In this formulation a is 1 indexed (as oposed to being 0 indexed)
@@ -28,7 +29,7 @@ where
     /// resulting in a single larger integer whose intermediary bits are no longer
     /// biased.
     fn as_bytes(&self) -> Self::ET {
-        let mut dst = [0u8; <P as EncodingSize>::ENCODED_SIZE];
+        let mut dst = Self::ET::from_fn(|_| 0u8);
         // we know there will be no size error and we know the key will be encodable
         // so we do not need the result.
         let _ = self.encode_priv(&mut dst);
@@ -51,37 +52,41 @@ where
 
 impl<P> Encodable for EncapsulationKey<P>
 where
-    P: KemCore + EncodingSize + FipsEncodingSize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
     fn is_encodable(&self) -> bool {
-        let mut dst = [0u8; <P as EncodingSize>::ENCODED_SIZE];
+        let mut dst = ByteArray::<<P as KemeleonByteArraySize>::ENCODED_EK_SIZE>::from_fn(|_| 0u8);
         self.encode_priv(&mut dst).expect("should never fail")
     }
 }
 
 impl<P> EncapsulationKey<P>
 where
-    P: KemCore + EncodingSize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
     fn decode_priv(c: impl AsRef<[u8]>) -> Result<Self, EncodeError> {
-        if c.as_ref().len() < P::ENCODED_SIZE {
+        let ek_len = <P as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE;
+        let t_hat_len = <P as EncodingSize>::T_HAT_LEN::USIZE;
+        const R_LEN: usize = RHO_LEN::USIZE;
+
+        if c.as_ref().len() < ek_len {
             return Err(EncodeError::invalid_ek_len(c.as_ref().len()));
         }
 
         // Get the random mask byte from the high order bits
-        let rand_byte = c.as_ref()[P::T_HAT_LEN - 1] & P::MSB_BITMASK;
+        let rand_byte = c.as_ref()[t_hat_len - 1] & P::MSB_BITMASK;
 
         // extract the value of rho
-        let mut rho = [0u8; RHO_LEN];
-        rho[..].clone_from_slice(&c.as_ref()[P::T_HAT_LEN..]);
+        let mut rho = [0u8; R_LEN];
+        rho[..].clone_from_slice(&c.as_ref()[t_hat_len..]);
 
         // Remove the randomized the high order bits by setting every bit above
         // the HIGH_ORDER_BIT to 0.
-        let mut bytes = c.as_ref()[..P::T_HAT_LEN].to_vec();
-        bytes[P::T_HAT_LEN - 1] &= P::MSB_BITMASK_INV;
+        let mut bytes = c.as_ref()[..t_hat_len].to_vec();
+        bytes[t_hat_len - 1] &= P::MSB_BITMASK_INV;
 
         // extract the values
-        let mut vals = [[0u16; ARR_LEN]; P::K];
+        let mut vals = Ntt::zero::<P>();
         vector_decode(&bytes, vals.as_flattened_mut())?;
 
         // Build the resulting key
@@ -89,24 +94,28 @@ where
     }
 
     fn encode_priv(&self, mut dst: impl AsMut<[u8]>) -> Result<bool, EncodeError> {
+        let ek_len = <P as KemeleonByteArraySize>::ENCODED_EK_SIZE::USIZE;
+        let t_hat_len = <P as EncodingSize>::T_HAT_LEN::USIZE;
+        const R_LEN: usize = RHO_LEN::USIZE;
+
         let k = dst.as_mut();
-        if k.len() < P::ENCODED_SIZE {
-            return Err(EncodeError::bad_dst_array(P::ENCODED_SIZE, k.len()));
+        if k.len() < ek_len {
+            return Err(EncodeError::bad_dst_array(ek_len, k.len()));
         }
 
         let vals_fips_encoded = self.key.as_bytes().to_vec();
         let (rho, vals) = fips::ek_decode::<P>(vals_fips_encoded);
 
-        let sample_success = vector_encode(vals.as_flattened(), &mut k[..P::T_HAT_LEN])?;
+        let sample_success = vector_encode(vals.as_flattened(), &mut k[..t_hat_len])?;
 
         // Clear the high order bit (and any bits above it)
-        k[P::T_HAT_LEN - 1] &= P::MSB_BITMASK_INV;
+        k[t_hat_len - 1] &= P::MSB_BITMASK_INV;
 
         // randomize the high order bits
-        k[P::T_HAT_LEN - 1] |= self.byte & P::MSB_BITMASK;
+        k[t_hat_len - 1] |= self.byte & P::MSB_BITMASK;
 
         // append rho
-        k[P::T_HAT_LEN..].copy_from_slice(&rho[..]);
+        k[t_hat_len..].copy_from_slice(&rho[..]);
 
         Ok(sample_success)
     }
@@ -120,17 +129,17 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{mlkem::Kemx, FieldElement, FipsEncodingSize};
+    use crate::{mlkem::Kemx, ByteArr, FieldElement, ARR_LEN_U};
     use ml_kem::{Encoded, MlKem1024, MlKem512, MlKem768};
     use num_bigint::BigUint;
 
     fn entropy_check<P>()
     where
-        P: KemCore + EncodingSize + FipsEncodingSize,
+        P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
     {
-        let ek_kb = [0xff; P::ENCODED_SIZE];
+        let ek_kb = ByteArray::<<P as KemeleonByteArraySize>::ENCODED_EK_SIZE>::from_fn(|_| 0xff_0u8);
         let ek = EncapsulationKey::<P>::try_from_bytes(ek_kb).expect("failed to parse key");
-        // println!("{:02x}", ek.key.as_bytes()[P::FIPS_ENCODED_SIZE - RHO_LEN-1]);
+        // println!("{:02x}", ek.key.as_bytes()[<P as FipsByteArraySize>::ENCODED_EK_SIZE::USIZE - RHO_LEN-1]);
 
         // all bits 1 => random mask byte will match the high bit mask
         assert_eq!(P::MSB_BITMASK, ek.byte);
@@ -157,10 +166,10 @@ mod tests {
     #[allow(clippy::cast_possible_wrap)]
     fn sample_boundary_check<P>()
     where
-        P: KemCore + EncodingSize + FipsEncodingSize,
+        P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
     {
-        let ek_kb = [0xff_u8; P::ENCODED_SIZE];
-        let max_ek_k = EncapsulationKey::decode_priv(ek_kb).unwrap();
+        let ek_kb = ByteArray::<<P as KemeleonByteArraySize>::ENCODED_EK_SIZE>::from_fn(|_| 0xff_0u8);
+        let max_ek_k = EncapsulationKey::<P>::decode_priv(ek_kb).unwrap();
         let ek_fips_b = max_ek_k.key.as_bytes();
         let (rho, max_ntt_vals) = fips::ek_decode(ek_fips_b);
 
@@ -172,7 +181,7 @@ mod tests {
             t_hat[0][0] = (t_hat[0][0] as i16 + k) as u16;
             let ek_k = EncapsulationKey::from_parts(&t_hat, &rho, 0xff);
 
-            let mut dst = [0u8; P::ENCODED_SIZE];
+            let mut dst = ByteArr::zero::<<P as KemeleonByteArraySize>::ENCODED_EK_SIZE>(); // [0u8; P::ENCODED_EK_SIZE];
             let sample_success = ek_k.encode_priv(&mut dst).expect("encode failed");
 
             assert_eq!(sample_success, k <= 0, "{k} incorrect");
@@ -180,11 +189,11 @@ mod tests {
 
         // Similarly incrementing the high order byte will be high enough to overflow
         // into the HIGH_ORDER_BIT - making it unencodable.
-        let mut t_hat = [[0_u16; ARR_LEN]; P::K];
-        t_hat[P::K - 1][ARR_LEN - 1] = max_ntt_vals[P::K - 1][ARR_LEN - 1] + 1;
+        let mut t_hat = Ntt::zero::<P>();
+        t_hat[P::K::USIZE - 1][ARR_LEN_U - 1] = max_ntt_vals[P::K::USIZE - 1][ARR_LEN_U - 1] + 1;
         let ek_k = EncapsulationKey::from_parts(&t_hat, &rho, 0xff);
 
-        let mut dst = [0u8; P::ENCODED_SIZE];
+        let mut dst = ByteArr::zero::<<P as KemeleonByteArraySize>::ENCODED_EK_SIZE>();
         let sample_success = ek_k.encode_priv(&mut dst).expect("encode failed");
 
         assert!(!sample_success, "increment high order byte incorrect");
@@ -200,7 +209,7 @@ mod tests {
 
     fn consistency_check<P>()
     where
-        P: KemCore + EncodingSize + FipsEncodingSize,
+        P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
     {
         let mut rng = rand::thread_rng();
         // This is the repeated-trial generate function and any key created
@@ -227,7 +236,7 @@ mod tests {
 
     fn value_check<P>(b: &[u8], v: &BigUint, description: &str)
     where
-        P: KemCore + EncodingSize,
+        P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
     {
         let encoded = Encoded::<P::EncapsulationKey>::try_from(b).unwrap();
         let key = EncapsulationKey::<P> {
@@ -243,9 +252,9 @@ mod tests {
     // make sure specific values map in the way we expect them to.
     fn specific_values_trial<P>()
     where
-        P: KemCore + EncodingSize + FipsEncodingSize,
+        P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
     {
-        let zero = [0u8; P::FIPS_ENCODED_SIZE];
+        let zero =  ByteArr::zero::<<P as FipsByteArraySize>::ENCODED_EK_SIZE>();
         value_check(&zero, &BigUint::ZERO, "zero");
 
         // 01 00 -> 01
@@ -284,26 +293,26 @@ mod tests {
 
         // 00000000... 00 00 10 00 ->  3329 ^(P::K * 256 - 1)
         let mut x = zero;
-        x[P::FIPS_ENCODED_SIZE - RHO_LEN - 2] = 0x10_u8;
+        x[<P as FipsByteArraySize>::ENCODED_EK_SIZE::USIZE - RHO_LEN::USIZE - 2] = 0x10_u8;
         value_check(
             &x,
-            &BigUint::from(3329_u64).pow((P::K * ARR_LEN - 1) as u32),
+            &BigUint::from(3329_u64).pow((P::K * ARR_LEN_U - 1) as u32),
             ".... 00 01 00 => 3329 ^(P::K * 256 - 1)",
         );
 
         // 00000000... 0000f00f ->  (0xff) * 3329 ^(P::K * 256 - 1)
         let mut x = zero;
-        x[P::FIPS_ENCODED_SIZE - RHO_LEN - 1] = 0x0f_u8;
-        x[P::FIPS_ENCODED_SIZE - RHO_LEN - 2] = 0xf0_u8;
+        x[<P as FipsByteArraySize>::ENCODED_EK_SIZE::USIZE - RHO_LEN::USIZE - 1] = 0x0f_u8;
+        x[<P as FipsByteArraySize>::ENCODED_EK_SIZE::USIZE - RHO_LEN::USIZE - 2] = 0xf0_u8;
         value_check(
             &x,
-            &(BigUint::from(0x00ff_u64) * BigUint::from(3329_u64).pow((P::K * ARR_LEN - 1) as u32)),
+            &(BigUint::from(0x00ff_u64) * BigUint::from(3329_u64).pow((P::K * ARR_LEN_U - 1) as u32)),
             ".... 00 f0 0f => (0x0ff) * 3329 ^(P::K * 256 - 1)",
         );
 
         // 00000000... 00 00 00 00 | ff ->  0
         let mut x = zero;
-        x[P::FIPS_ENCODED_SIZE - RHO_LEN] = 0xff_u8;
+        x[<P as FipsByteArraySize>::ENCODED_EK_SIZE::USIZE - RHO_LEN::USIZE] = 0xff_u8;
         value_check(&x, &BigUint::ZERO, ".... 00 00 00 | ff => 0");
     }
 
@@ -316,7 +325,7 @@ mod tests {
 
     fn encode_decode_trial<P>()
     where
-        P: KemCore + EncodingSize + FipsEncodingSize,
+        P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
     {
         let mut rng = rand::thread_rng();
         // This is the repeated trial generate from random and any key created
@@ -358,7 +367,7 @@ mod tests {
         };
 
         // Encode encapsulation key using Kemeleon
-        let mut dst = [0u8; MlKem512::ENCODED_SIZE];
+        let mut dst = ByteArr::zero::<<MlKem512 as KemeleonByteArraySize>::ENCODED_EK_SIZE>();
         let encodable = ek_in.encode_priv(&mut dst).expect("failed kemeleon encode");
         assert!(
             encodable,
@@ -420,7 +429,7 @@ mod tests {
             let mut v = BigUint::ZERO;
             let mut offset = BigUint::from(1_u64);
             for _ in 0..k {
-                for _ in 0..ARR_LEN {
+                for _ in 0..ARR_LEN_U {
                     v += 3328_u16 * &offset;
                     offset *= &base;
                 }
@@ -439,7 +448,7 @@ mod tests {
         }
 
         let q = BigUint::from(FieldElement::Q64);
-        let max_value = q.pow(ARR_LEN as u32 * 3_u32) - 1u32;
+        let max_value = q.pow(ARR_LEN_U as u32 * 3_u32) - 1u32;
         let max_val_bits: u32 = max_value.bits() as u32;
         // println!("{} {}", max_val_bits, hex::encode(max_value.to_bytes_le()));
 

--- a/src/kemeleon/encapsulation_key.rs
+++ b/src/kemeleon/encapsulation_key.rs
@@ -10,10 +10,6 @@ use ml_kem::{EncodedSizeUser, KemCore};
 impl<P> Encode for EncapsulationKey<P>
 where
     P: KemCore + EncodingSize + FipsEncodingSize,
-    [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::K]:,
-    [(); P::USIZE]:,
 {
     type ET = Barr8<{ <P as EncodingSize>::ENCODED_SIZE }>;
     type Error = EncodeError;
@@ -56,10 +52,6 @@ where
 impl<P> Encodable for EncapsulationKey<P>
 where
     P: KemCore + EncodingSize + FipsEncodingSize,
-    [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::K]:,
-    [(); P::USIZE]:,
 {
     fn is_encodable(&self) -> bool {
         let mut dst = [0u8; <P as EncodingSize>::ENCODED_SIZE];
@@ -70,10 +62,6 @@ where
 impl<P> EncapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::K]:,
-    [(); P::USIZE]:,
 {
     fn decode_priv(c: impl AsRef<[u8]>) -> Result<Self, EncodeError> {
         if c.as_ref().len() < P::ENCODED_SIZE {
@@ -139,10 +127,6 @@ mod tests {
     fn entropy_check<P>()
     where
         P: KemCore + EncodingSize + FipsEncodingSize,
-        [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::K]:,
-        [(); P::USIZE]:,
     {
         let ek_kb = [0xff; P::ENCODED_SIZE];
         let ek = EncapsulationKey::<P>::try_from_bytes(ek_kb).expect("failed to parse key");
@@ -174,10 +158,6 @@ mod tests {
     fn sample_boundary_check<P>()
     where
         P: KemCore + EncodingSize + FipsEncodingSize,
-        [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::K]:,
-        [(); P::USIZE]:,
     {
         let ek_kb = [0xff_u8; P::ENCODED_SIZE];
         let max_ek_k = EncapsulationKey::decode_priv(ek_kb).unwrap();
@@ -221,10 +201,6 @@ mod tests {
     fn consistency_check<P>()
     where
         P: KemCore + EncodingSize + FipsEncodingSize,
-        [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::K]:,
-        [(); P::USIZE]:,
     {
         let mut rng = rand::thread_rng();
         // This is the repeated-trial generate function and any key created
@@ -252,10 +228,6 @@ mod tests {
     fn value_check<P>(b: &[u8], v: &BigUint, description: &str)
     where
         P: KemCore + EncodingSize,
-        [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::K]:,
-        [(); P::USIZE]:,
     {
         let encoded = Encoded::<P::EncapsulationKey>::try_from(b).unwrap();
         let key = EncapsulationKey::<P> {
@@ -272,10 +244,6 @@ mod tests {
     fn specific_values_trial<P>()
     where
         P: KemCore + EncodingSize + FipsEncodingSize,
-        [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::K]:,
-        [(); P::USIZE]:,
     {
         let zero = [0u8; P::FIPS_ENCODED_SIZE];
         value_check(&zero, &BigUint::ZERO, "zero");
@@ -349,10 +317,6 @@ mod tests {
     fn encode_decode_trial<P>()
     where
         P: KemCore + EncodingSize + FipsEncodingSize,
-        [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::ENCODED_SIZE]:,
-        [(); <P as EncodingSize>::K]:,
-        [(); P::USIZE]:,
     {
         let mut rng = rand::thread_rng();
         // This is the repeated trial generate from random and any key created

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ where
 //                          Kemeleon
 // ========================================================================== //
 
-///
+/// Ciphertext U and V inner element sizes required for encoding and decoding.
 #[allow(non_camel_case_types)]
 pub trait KemeleonEncodingSize: EncodingSize {
     /// Size of the U value of the kemeleon encoded ciphertext. Matches `T_HAT_LEN`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use hybrid_array::{
     sizes::{U1124, U1498, U749},
     typenum::{
         operator_aliases::{Prod, Sum},
-        Unsigned, U10, U11, U12, U2, U256, U3, U32, U384, U4, U5,
+        U10, U11, U12, U2, U256, U3, U32, U384, U4, U5,
     },
     Array, ArraySize,
 };
@@ -60,15 +60,13 @@ impl From<u16> for FieldElement {
 
 #[allow(non_camel_case_types)]
 type ARR_LEN = U256;
-const ARR_LEN_U: usize = ARR_LEN::USIZE;
 #[allow(non_camel_case_types)]
 type RHO_LEN = U32;
 
 /// byte array
-type ByteArray<N: ArraySize> = Array<u8, N>;
+type ByteArray<N> = Array<u8, N>;
 /// value array -- array of polynomial values
-type ValueArray<P: EncodingSize> = Array<Array<u16, ARR_LEN>, P::K>;
-type NttArray<P: EncodingSize> = ValueArray<P>;
+type NttArray<P> = Array<Array<u16, ARR_LEN>, <P as EncodingSize>::K>;
 struct Ntt;
 
 impl Ntt {
@@ -84,12 +82,6 @@ impl ByteArr {
         ByteArray::<N>::from_fn(|_| 0u8)
     }
 }
-
-trait Init {
-    fn zero() -> Self;
-}
-
-
 
 #[allow(dead_code)]
 impl FieldElement {
@@ -171,10 +163,6 @@ impl<T: EncodingSize> KemeleonEncodingSize for T
 where
     <T as EncodingSize>::DV: Mul<U32>,
     <<T as EncodingSize>::DV as Mul<U32>>::Output: ArraySize,
-
-    <T as EncodingSize>::T_HAT_LEN: Add<<<T as EncodingSize>::DV as Mul<U32>>::Output>,
-    <<T as EncodingSize>::T_HAT_LEN as Add<<<T as EncodingSize>::DV as Mul<U32>>::Output>>::Output:
-        ArraySize,
 {
     type ENCODED_USIZE = T::T_HAT_LEN;
     type ENCODED_VSIZE = Prod<Self::DV, U32>;
@@ -308,7 +296,8 @@ pub type MlKem1024 = mlkem::Kemx<ml_kem::MlKem1024>;
 impl<P> EncodingSize for mlkem::Kemx<P>
 where
     P: ml_kem::KemCore + EncodingSize,
-{ //_1011_1001_0100
+{
+    //_1011_1001_0100
     type USIZE = P::USIZE;
     type K = P::K;
     type DU = P::DU;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![doc = include_str!("../README.md")]
 
 use core::fmt::Debug;
+use core::ops::{Add, Div, Mul, Rem, Sub};
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -19,8 +20,16 @@ mod kemeleon;
 mod mlkem;
 
 pub use errors::*;
-use hybrid_array::ArraySize;
 pub use kemeleon::*;
+
+use hybrid_array::{
+    typenum::{
+        operator_aliases::{Gcf, Prod, Quot, Sum},
+        type_operators::Gcd,
+        Const, ToUInt, U0, U12, U16, U2, U256, U3, U32, U384, U4, U6, U64, U8,
+    },
+    Array, ArraySize,
+};
 
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd)]
 pub(crate) struct FieldElement(pub u16);
@@ -49,14 +58,14 @@ impl From<u16> for FieldElement {
     }
 }
 
-const ARR_LEN: usize = 256;
-const RHO_LEN: usize = 32;
+type ARR_LEN = U256;
+type RHO_LEN = U32;
 
 /// byte array
 type Barr8<const N: usize> = [u8; N];
 /// value array -- array of polynomial values
-type ValueArray<const N: usize, const K: usize> = [[u16; N]; K];
-type NttArray<const K: usize> = ValueArray<ARR_LEN, K>;
+type ValueArray<P: EncodingSize> = Array<Array<u16, ARR_LEN>, P::K>;
+type NttArray<P: EncodingSize> = ValueArray<P>;
 
 #[allow(dead_code)]
 impl FieldElement {
@@ -110,7 +119,7 @@ pub trait EncodingSize {
     /// Number of bytes for just `t_hat` values in a kemeleon encoded value
     ///
     /// Computed as: $\left\lceil (HIGH\\_ORDER\\_BIT -1)/8 \right\rceil$
-    const T_HAT_LEN: usize;
+    type T_HAT_LEN: ArraySize;
 
     /// Bitmask for the high order byte which will be less than a full byte of
     /// random bits when encoded.
@@ -122,46 +131,127 @@ pub trait EncodingSize {
     const MSB_BITMASK_INV: u8 = !Self::MSB_BITMASK;
 }
 
-pub trait KemeleonEncodingSize: EncodingSize {
+pub trait KemeleonEncodingSize: EncodingSize
+where
+    <Self::ENCODED_USIZE as Add<Self::ENCODED_VSIZE>>::Output: ArraySize
+{
     /// Size of the Kemeleon encoded string as bytes.
     ///
     /// Computed as: $T\\_HAT\\_LEN + RHO\\_LEN$
-    const ENCODED_SIZE: usize = Self::T_HAT_LEN + RHO_LEN;
+    type ENCODED_SIZE: ArraySize;
 
     /// Size of the U value of the kemeleon encoded ciphertext. Matches `T_HAT_LEN`.
-    const ENCODED_USIZE: usize = Self::T_HAT_LEN;
+    type ENCODED_USIZE: ArraySize + Add<Self::ENCODED_VSIZE>;
     #[allow(clippy::doc_markdown)]
     /// Size of the V value of the Kemeleon encoded ciphertext. N values of Dv Bit size.
     /// The number of bytes is computed as $ ENCODED_VSIZE = n * D_v / 8 \text{ --- for } n=256 $
-    type ENCODED_VSIZE: usize = Prod<U32, Self::DV>::OutputSize;
-    /// Size of the combined kemeleon encoded ciphertext.
-    const ENCODED_CT_SIZE: usize = Self::ENCODED_USIZE + Self::ENCODED_VSIZE;
+    type ENCODED_VSIZE: ArraySize;
+    // /// Size of the combined kemeleon encoded ciphertext.
+    // type ENCODED_CT_SIZE: ArraySize;
 }
+
+impl<T: EncodingSize> KemeleonEncodingSize for T
+where
+    <T as EncodingSize>::T_HAT_LEN: Add<RHO_LEN>,
+    <<T as EncodingSize>::T_HAT_LEN as Add<RHO_LEN>>::Output: ArraySize,
+
+    <T as EncodingSize>::DV: Mul<U32>,
+    <<T as EncodingSize>::DV as Mul<U32>>::Output: ArraySize,
+{
+    /// Size of the Kemeleon encoded string as bytes.
+    ///
+    /// Computed as: $T\\_HAT\\_LEN + RHO\\_LEN$
+    type ENCODED_SIZE = Sum<Self::T_HAT_LEN, RHO_LEN>;
+
+    /// Size of the U value of the kemeleon encoded ciphertext. Matches `T_HAT_LEN`.
+    type ENCODED_USIZE = T::T_HAT_LEN;
+
+    #[allow(clippy::doc_markdown)]
+    /// Size of the V value of the Kemeleon encoded ciphertext. N values of Dv Bit size.
+    /// The number of bytes is computed as $ ENCODED_VSIZE = n * D_v / 8 \text{ --- for } n=256 $
+    type ENCODED_VSIZE = Prod<Self::DV, U32>;
+    // /// Size of the combined kemeleon encoded ciphertext.
+    // type ENCODED_CT_SIZE = Sum<Self::ENCODED_USIZE, Self::ENCODED_VSIZE>;
+}
+
 
 /// Fips encoding size values
 pub trait FipsEncodingSize: EncodingSize {
     /// Length of an NTT Vector encoded and compressed
-    const FIPS_T_HAT_LEN: usize = Self::K * 12 * 32;
-    /// Length of an encoded FIPS encapsulation key
-    const FIPS_ENCODED_SIZE: usize = Self::FIPS_T_HAT_LEN + RHO_LEN;
+    type FIPS_T_HAT_LEN: ArraySize;
 
     /// Size of the compressed U element of an ML-KEM ciphertext. $Du * K * 256 / 8$
-    const FIPS_ENCODED_USIZE: usize = U32 * Self::DU * Self::K;
+    type FIPS_ENCODED_USIZE: ArraySize;
     /// Size of the compressed V element of an ML-KEM ciphertext. $Dv * 256 / 8$
-    const FIPS_ENCODED_VSIZE: usize = U32 * Self::DV;
-    /// Size of a ciphertext encoded and compressed using FIPS standard.
-    const FIPS_ENCODED_CT_SIZE: usize = Self::FIPS_ENCODED_USIZE + Self::FIPS_ENCODED_VSIZE;
+    type FIPS_ENCODED_VSIZE: ArraySize;
 }
-impl<T: EncodingSize> FipsEncodingSize for T {}
 
-use hybrid_array::typenum::{U2, U3, U4, U5, U10, U11, U12, U32};
+
+impl<T: EncodingSize> FipsEncodingSize for T
+where
+    <T as EncodingSize>::K: Mul<U384>,
+    <<T as EncodingSize>::K as Mul<U384>>::Output: ArraySize,
+
+    <T as EncodingSize>::DV: Mul<U32>,
+    <<T as EncodingSize>::DV as Mul<U32>>::Output: ArraySize,
+
+    <T as EncodingSize>::K: Mul<<T as EncodingSize>::DU>,
+    <<T as EncodingSize>::K as Mul<<T as EncodingSize>::DU>>::Output: ArraySize,
+
+{
+    /// Length of an NTT Vector encoded and compressed K * 12 * (256/8) = K * 384
+    type FIPS_T_HAT_LEN = Prod<Self::K, U384>;
+
+    /// Size of the compressed U element of an ML-KEM ciphertext. $Du * K * 256 / 8$
+    type FIPS_ENCODED_USIZE = Prod<Prod<T::K, T::DU>, U32>;
+    /// Size of the compressed V element of an ML-KEM ciphertext. $Dv * 256 / 8$
+    type FIPS_ENCODED_VSIZE = Prod<T::DV, U32>;
+}
+
+trait ByteArraySize {
+    /// Length of an encoded encapsulation key
+    type ENCODED_EK_SIZE: ArraySize;
+
+    /// Size of a ciphertext encoded and compressed.
+    type ENCODED_CT_SIZE: ArraySize;
+}
+
+impl<T: FipsEncodingSize> ByteArraySize for T
+where
+    <T as FipsEncodingSize>::FIPS_ENCODED_USIZE: Add<<T as FipsEncodingSize>::FIPS_ENCODED_VSIZE>,
+    <<T as FipsEncodingSize>::FIPS_ENCODED_USIZE as Add<<T as FipsEncodingSize>::FIPS_ENCODED_VSIZE>>::Output: ArraySize,
+
+    <T as FipsEncodingSize>::FIPS_T_HAT_LEN: Add<RHO_LEN>,
+    <<T as FipsEncodingSize>::FIPS_T_HAT_LEN as Add<RHO_LEN>>::Output: ArraySize,
+{
+    type ENCODED_EK_SIZE = Sum<T::FIPS_T_HAT_LEN, RHO_LEN>;
+    
+    type ENCODED_CT_SIZE = Sum<T::FIPS_ENCODED_USIZE, T::FIPS_ENCODED_VSIZE>;
+}
+
+impl<T: KemeleonEncodingSize> ByteArraySize for T
+where
+    <T as KemeleonEncodingSize>::ENCODED_USIZE: Add<<T as KemeleonEncodingSize>::ENCODED_VSIZE>,
+    <<T as KemeleonEncodingSize>::ENCODED_USIZE as Add<<T as KemeleonEncodingSize>::ENCODED_VSIZE>>::Output: ArraySize,
+
+    <T as KemeleonEncodingSize>::T_HAT_LEN: Add<RHO_LEN>,
+    <<T as KemeleonEncodingSize>::T_HAT_LEN as Add<RHO_LEN>>::Output: ArraySize,
+{
+    type ENCODED_EK_SIZE = Sum<T::T_HAT_LEN, RHO_LEN>;
+    
+    type ENCODED_CT_SIZE = Sum<T::ENCODED_USIZE, T::ENCODED_VSIZE>;
+}
+
+
+use hybrid_array::{typenum::{U5, U10, U11, }, sizes::{U749, U1124, U1498}};
+
 impl EncodingSize for ml_kem::MlKem512 {
     type USIZE = U12;
     type K = U2;
     type DU = U10;
     type DV = U4;
 
-    const T_HAT_LEN: usize = 749;
+    type T_HAT_LEN = U749;
     const MSB_BITMASK: u8 = 0b1100_0000;
 }
 
@@ -171,7 +261,7 @@ impl EncodingSize for ml_kem::MlKem768 {
     type DU = U10;
     type DV = U4;
 
-    const T_HAT_LEN: usize = 1124;
+    type T_HAT_LEN = U1124;
     const MSB_BITMASK: u8 = 0b1111_1100;
 }
 
@@ -181,7 +271,7 @@ impl EncodingSize for ml_kem::MlKem1024 {
     type DU = U11;
     type DV = U5;
 
-    const T_HAT_LEN: usize = 1498;
+    type T_HAT_LEN = U1498;
     const MSB_BITMASK: u8 = 0b1110_0000;
 }
 
@@ -202,10 +292,11 @@ impl<P> EncodingSize for mlkem::Kemx<P>
 where
     P: ml_kem::KemCore + EncodingSize,
 {
-    const K: usize = P::K;
-    const DU: usize = P::DU;
-    const DV: usize = P::DV;
+    type USIZE = P::USIZE;
+    type K = P::K;
+    type DU = P::DU;
+    type DV = P::DV;
 
-    const T_HAT_LEN: usize = P::T_HAT_LEN;
+    type T_HAT_LEN = P::T_HAT_LEN;
     const MSB_BITMASK: u8 = P::MSB_BITMASK;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use hybrid_array::{
     sizes::{U1124, U1498, U749},
     typenum::{
         operator_aliases::{Prod, Sum},
-        U10, U11, U12, U2, U256, U3, U32, U384, U4, U5,
+        Unsigned, U10, U11, U12, U2, U256, U3, U32, U384, U4, U5,
     },
     Array, ArraySize,
 };
@@ -60,6 +60,7 @@ impl From<u16> for FieldElement {
 
 #[allow(non_camel_case_types)]
 type ARR_LEN = U256;
+const ARR_LEN_U: usize = ARR_LEN::USIZE;
 #[allow(non_camel_case_types)]
 type RHO_LEN = U32;
 
@@ -68,6 +69,27 @@ type ByteArray<N: ArraySize> = Array<u8, N>;
 /// value array -- array of polynomial values
 type ValueArray<P: EncodingSize> = Array<Array<u16, ARR_LEN>, P::K>;
 type NttArray<P: EncodingSize> = ValueArray<P>;
+struct Ntt;
+
+impl Ntt {
+    fn zero<P: EncodingSize>() -> NttArray<P> {
+        Array::<Array<u16, ARR_LEN>, P::K>::from_fn(|_| Array::<u16, ARR_LEN>::from_fn(|_| 0u16))
+    }
+}
+
+struct ByteArr;
+
+impl ByteArr {
+    fn zero<N: ArraySize>() -> ByteArray<N> {
+        ByteArray::<N>::from_fn(|_| 0u8)
+    }
+}
+
+trait Init {
+    fn zero() -> Self;
+}
+
+
 
 #[allow(dead_code)]
 impl FieldElement {

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -444,7 +444,7 @@ mod test {
     #[test]
     fn coverage() {
         coverage_trial::<MlKem512>();
-        coverage_trial::<MlKem768>();
-        coverage_trial::<MlKem1024>();
+        // coverage_trial::<MlKem768>();
+        // coverage_trial::<MlKem1024>();
     }
 }

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -230,6 +230,15 @@ where
     }
 }
 
+impl<P> From<&Array<u8, <P as KemeleonByteArraySize>::ENCODED_CT_SIZE>> for KCiphertext<P>
+where
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
+{
+    fn from(value: &Array<u8, <P as KemeleonByteArraySize>::ENCODED_CT_SIZE>) -> Self {
+        KCiphertext::decode(value).unwrap()
+    }
+}
+
 impl<P> TryFrom<&[u8]> for KEncodedCiphertext<P>
 where
     P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
@@ -406,7 +415,9 @@ mod test {
 
         // KCiphertext try_from &[u8]
         let _ct = KCiphertext::<P>::try_from(&ct_arr[..]).expect("failed parse");
-        // KCiphertext from [u8; ENCODED_CT_SIZE]
+        // KCiphertext from Array<u8, ENCODED_CT_SIZE>
+        let _ct = KCiphertext::<P>::from(ct_arr.clone());
+        // KCiphertext from &Array<u8, ENCODED_CT_SIZE>
         let _ct = KCiphertext::<P>::from(&ct_arr);
         // KEncodedCiphertext try_from &[u8]
         let _ct = KEncodedCiphertext::<P>::try_from(&ct_arr[..]).expect("failed parse");

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -204,6 +204,15 @@ where
     }
 }
 
+impl<P> From<&Array<u8, P::ENCODED_CT_SIZE>> for KEncodedCiphertext<P>
+where
+    P: KemCore + KemeleonByteArraySize,
+{
+    fn from(value: &Array<u8, P::ENCODED_CT_SIZE>) -> Self {
+        KEncodedCiphertext(value.clone())
+    }
+}
+
 impl<P> From<Array<u8, P::ENCODED_CT_SIZE>> for KEncodedCiphertext<P>
 where
     P: KemCore + KemeleonByteArraySize,
@@ -213,18 +222,18 @@ where
     }
 }
 
-impl<P> From<Array<u8, P::ENCODED_CT_SIZE>> for KCiphertext<P>
+impl<P> From<Array<u8, <P as KemeleonByteArraySize>::ENCODED_CT_SIZE>> for KCiphertext<P>
 where
-    P: KemCore + KemeleonByteArraySize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
-    fn from(value: Array<u8, P::ENCODED_CT_SIZE>) -> Self {
+    fn from(value: Array<u8, <P as KemeleonByteArraySize>::ENCODED_CT_SIZE>) -> Self {
         KCiphertext::decode(value).unwrap()
     }
 }
 
 impl<P> TryFrom<&[u8]> for KEncodedCiphertext<P>
 where
-    P: KemCore + KemeleonByteArraySize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
     type Error = EncodeError;
 
@@ -235,7 +244,7 @@ where
 
 impl<P> TryFrom<&[u8]> for KCiphertext<P>
 where
-    P: KemCore + KemeleonByteArraySize,
+    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
 {
     type Error = EncodeError;
     fn try_from(buf: &[u8]) -> Result<Self, EncodeError> {
@@ -255,7 +264,7 @@ where
 
 impl<P> Decapsulate<KEncodedCiphertext<P>, SharedKey<P>> for KDecapsulationKey<P>
 where
-    P: KemCore + KemeleonByteArraySize,
+    P: KemCore +  FipsByteArraySize + KemeleonByteArraySize,
 {
     type Error = EncodeError;
 
@@ -325,7 +334,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{ByteArray, KemeleonByteArraySize};
+    use crate::{ByteArr, KemeleonByteArraySize};
 
     use super::*;
 
@@ -394,13 +403,13 @@ mod test {
         assert_eq!(sk, k_recv);
 
         let mut ct_arr =
-            ByteArray::<<P as KemeleonByteArraySize>::ENCODED_CT_SIZE>::from_fn(|_| 0u8);
+            ByteArr::zero::<<P as KemeleonByteArraySize>::ENCODED_CT_SIZE>();
         ct_arr.copy_from_slice(&ct.as_bytes());
 
         // KCiphertext try_from &[u8]
         let _ct = KCiphertext::<P>::try_from(&ct_arr[..]).expect("failed parse");
         // KCiphertext from [u8; ENCODED_CT_SIZE]
-        let _ct = KCiphertext::<P>::from(ct_arr);
+        let _ct = KCiphertext::<P>::from(&ct_arr);
         // KEncodedCiphertext try_from &[u8]
         let _ct = KEncodedCiphertext::<P>::try_from(&ct_arr[..]).expect("failed parse");
         // KEncodedCiphertext from [u8; ENCODED_CT_SIZE]

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -75,7 +75,7 @@ where
     #[must_use]
     /// Construct a local object representing an Encapsulation key from the FIPS byte
     /// representations of the individual parts of the key.
-    pub fn from_parts(t_hat: &[[u16; ARR_LEN]; P::K], rho: &[u8; 32], mask_byte: u8) -> Self {
+    pub fn from_parts(t_hat: &[[u16; ARR_LEN::USIZE]; P::K::USIZE], rho: &[u8; 32], mask_byte: u8) -> Self {
         let ek_fb = fips::ek_encode(rho, t_hat);
         Self::from_fips_bytes(ek_fb, mask_byte)
     }

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -27,10 +27,6 @@ where
 impl<P> Kemx<P>
 where
     P: ml_kem::KemCore + EncodingSize,
-    [(); <P as FipsEncodingSize>::FIPS_ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::ENCODED_SIZE]:,
-    [(); <P as EncodingSize>::K]:,
-    [(); P::USIZE]:,
 {
     pub fn generate(rng: &mut impl CryptoRngCore) -> (KDecapsulationKey<P>, KEncapsulationKey<P>) {
         // random u8 for the most significant byte which will be less than 8 bits.
@@ -74,8 +70,6 @@ where
 impl<P> KEncapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::FIPS_ENCODED_SIZE]:,
-    [(); P::USIZE]:,
 {
     // TODO: must use for now -- not sure it this will stay
     #[must_use]
@@ -111,11 +105,6 @@ where
 impl<P> Encapsulate<KEncodedCiphertext<P>, SharedKey<P>> for KEncapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
 {
     type Error = EncodeError;
 
@@ -144,11 +133,6 @@ where
 impl<P> EncapsulateDeterministic<KEncodedCiphertext<P>, SharedKey<P>> for KEncapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
 {
     type Error = EncodeError;
 
@@ -197,7 +181,6 @@ where
 pub struct KCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::ENCODED_CT_SIZE]:,
 {
     pub(crate) encoded: bool,
     pub(crate) bytes: [u8; P::ENCODED_CT_SIZE],
@@ -206,13 +189,11 @@ where
 
 pub struct KEncodedCiphertext<P>(pub(crate) [u8; P::ENCODED_CT_SIZE])
 where
-    P: KemCore + EncodingSize,
-    [(); P::ENCODED_CT_SIZE]:;
+    P: KemCore + EncodingSize;
 
 impl<P> AsRef<[u8]> for KEncodedCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::ENCODED_CT_SIZE]:,
 {
     fn as_ref(&self) -> &[u8] {
         &self.0
@@ -222,7 +203,6 @@ where
 impl<P> From<[u8; P::ENCODED_CT_SIZE]> for KEncodedCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::ENCODED_CT_SIZE]:,
 {
     fn from(value: [u8; P::ENCODED_CT_SIZE]) -> Self {
         KEncodedCiphertext(value)
@@ -232,13 +212,6 @@ where
 impl<P> From<[u8; P::ENCODED_CT_SIZE]> for KCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
-    [(); P::FIPS_ENCODED_USIZE]:,
-    [(); P::FIPS_ENCODED_CT_SIZE]:,
 {
     fn from(value: [u8; P::ENCODED_CT_SIZE]) -> Self {
         KCiphertext::decode(value).unwrap()
@@ -248,11 +221,6 @@ where
 impl<P> TryFrom<&[u8]> for KEncodedCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
 {
     type Error = EncodeError;
 
@@ -264,13 +232,6 @@ where
 impl<P> TryFrom<&[u8]> for KCiphertext<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
-    [(); P::FIPS_ENCODED_USIZE]:,
-    [(); P::FIPS_ENCODED_CT_SIZE]:,
 {
     type Error = EncodeError;
     fn try_from(buf: &[u8]) -> Result<Self, EncodeError> {
@@ -291,13 +252,6 @@ where
 impl<P> Decapsulate<KEncodedCiphertext<P>, SharedKey<P>> for KDecapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
-    [(); P::FIPS_ENCODED_USIZE]:,
-    [(); P::FIPS_ENCODED_CT_SIZE]:,
 {
     type Error = EncodeError;
 
@@ -313,13 +267,6 @@ where
 impl<P> Decapsulate<KCiphertext<P>, SharedKey<P>> for KDecapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
-    [(); P::FIPS_ENCODED_USIZE]:,
-    [(); P::FIPS_ENCODED_CT_SIZE]:,
 {
     type Error = EncodeError;
 
@@ -333,13 +280,6 @@ where
 impl<P> Decapsulate<Ciphertext<P>, SharedKey<P>> for KDecapsulationKey<P>
 where
     P: KemCore + EncodingSize,
-    [(); P::K]:,
-    [(); P::DU]:,
-    [(); P::ENCODED_SIZE]:,
-    [(); P::ENCODED_CT_SIZE]:,
-    [(); P::FIPS_ENCODED_SIZE]:,
-    [(); P::FIPS_ENCODED_USIZE]:,
-    [(); P::FIPS_ENCODED_CT_SIZE]:,
 {
     type Error = EncodeError;
 
@@ -388,14 +328,6 @@ mod test {
     fn generate_trial<P>()
     where
         P: ml_kem::KemCore + EncodingSize,
-        [(); P::K]:,
-        [(); P::DU]:,
-        [(); P::USIZE]:,
-        [(); P::ENCODED_SIZE]:,
-        [(); P::ENCODED_CT_SIZE]:,
-        [(); P::FIPS_ENCODED_SIZE]:,
-        [(); P::FIPS_ENCODED_USIZE]:,
-        [(); P::FIPS_ENCODED_CT_SIZE]:,
     {
         let mut rng = rand::thread_rng();
         let (dk, ek) = Kemx::<P>::generate(&mut rng);
@@ -426,14 +358,6 @@ mod test {
     fn coverage_trial<P>()
     where
         P: ml_kem::KemCore + EncodingSize,
-        [(); P::K]:,
-        [(); P::DU]:,
-        [(); P::USIZE]:,
-        [(); P::ENCODED_SIZE]:,
-        [(); P::ENCODED_CT_SIZE]:,
-        [(); P::FIPS_ENCODED_SIZE]:,
-        [(); P::FIPS_ENCODED_USIZE]:,
-        [(); P::FIPS_ENCODED_CT_SIZE]:,
     {
         let mut rng = rand::thread_rng();
         let (dk, ek) = Kemx::<P>::generate(&mut rng);

--- a/tests/encap-decap.rs
+++ b/tests/encap-decap.rs
@@ -3,11 +3,10 @@
 use ml_kem::*;
 
 use ::kem::Decapsulate;
-use hybrid_array::Array;
 use std::{fs::read_to_string, path::PathBuf};
 
 #[test]
-pub fn acvp_encap_decap() {
+fn acvp_encap_decap() {
     // Load the JSON test file
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests/encap-decap.json");
@@ -36,7 +35,7 @@ fn verify_encap_group(tg: &acvp::EncapTestGroup) {
 }
 
 fn verify_encap<K: KemCore>(tc: &acvp::EncapTestCase) {
-    let m = Array::try_from(tc.m.as_slice()).unwrap();
+    let m = B32::try_from(tc.m.as_slice()).unwrap();
     let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(tc.ek.as_slice()).unwrap();
     let ek = K::EncapsulationKey::from_bytes(&ek_bytes);
 

--- a/tests/key-gen.rs
+++ b/tests/key-gen.rs
@@ -2,11 +2,10 @@
 
 use ml_kem::*;
 
-use hybrid_array::Array;
 use std::{fs::read_to_string, path::PathBuf};
 
 #[test]
-pub fn acvp_key_gen() {
+fn acvp_key_gen() {
     // Load the JSON test file
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.push("tests/key-gen.json");
@@ -29,8 +28,8 @@ pub fn acvp_key_gen() {
 
 fn verify<K: KemCore>(tc: &acvp::TestCase) {
     // Import test data into the relevant array structures
-    let d = Array::try_from(tc.d.as_slice()).unwrap();
-    let z = Array::try_from(tc.z.as_slice()).unwrap();
+    let d = B32::try_from(tc.d.as_slice()).unwrap();
+    let z = B32::try_from(tc.z.as_slice()).unwrap();
     let dk_bytes = Encoded::<K::DecapsulationKey>::try_from(tc.dk.as_slice()).unwrap();
     let ek_bytes = Encoded::<K::EncapsulationKey>::try_from(tc.ek.as_slice()).unwrap();
 


### PR DESCRIPTION
Generic constant expressions are [still unstable](https://doc.rust-lang.org/reference/items/generics.html) making them less than ideal for use in a stable package. 

A branch containing the original (generic const- based) implementation exists in case generic consts get stabilized at some point. 