### PR TITLE
Remove git based dependency in favor of new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,7 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 ml-kem = { version="0.2.1" }
-# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"]} 
-# hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], path = "/home/jmwample/svc/RustCrypto/hybrid-array" }
-hybrid-array = {version  = "0.2.0-rc.9", features=["extra-sizes"], git="https://github.com/RustCrypto/hybrid-array.git", branch="master"} 
+hybrid-array = {version  = "0.2.0-rc.10", features=["extra-sizes"]}
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"
 lazy_static = "1.5.0"


### PR DESCRIPTION
`hybrid-array` has incorporated the required changes into a (labeled) release as of `v0.2.0-rc.10`

This means we should be able to make an initial release of this package.