### PR TITLE
Using KemParams instead of KemCore 🫢

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 # ml-kem = { version = "0.3.0-pre" }
-ml-kem = { git="https://github.com/jmwample/KEMs.git",  branch="main"}
+# ml-kem = { git="https://github.com/jmwample/KEMs.git",  branch="main"}
+ml-kem = { path="../KEMs/ml-kem/" }
 hybrid-array = {version  = "0.2.0-rc.10", features=["extra-sizes"]}
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ alloc = []
 num-bigint = "0.4.6"
 rand = "0.8.5"
 # ml-kem = { version = "0.3.0-pre" }
-# ml-kem = { git="https://github.com/jmwample/KEMs.git",  branch="main"}
-ml-kem = { path="../KEMs/ml-kem/" }
+ml-kem = { git="https://github.com/jmwample/KEMs.git",  branch="params"}
+# ml-kem = { path="../KEMs/ml-kem/" }
 hybrid-array = {version  = "0.2.0-rc.10", features=["extra-sizes"]}
 rand_core = "0.6.4"
 kem = "0.3.0-pre.0"

--- a/src/fips.rs
+++ b/src/fips.rs
@@ -211,8 +211,8 @@ mod tests {
     use hex_literal::hex;
 
     use ml_kem::{
-        kem::Kem, Encoded, EncodedSizeUser, KemCore, KemParams, MlKem1024Params, MlKem512Params,
-        MlKem768Params,
+        kem::{Kem, Params as KemParams},
+        Encoded, EncodedSizeUser, KemCore, MlKem1024Params, MlKem512Params, MlKem768Params,
     };
 
     fn fips_encode_trial<P>()

--- a/src/kemeleon.rs
+++ b/src/kemeleon.rs
@@ -13,7 +13,7 @@ use crate::{EncodeError, EncodingSize, FieldElement, Obfuscated};
 use core::cmp::min;
 
 use hybrid_array::typenum::Unsigned;
-use ml_kem::KemCore;
+use ml_kem::KemParams;
 use num_bigint::BigUint;
 
 mod ciphertext;
@@ -31,7 +31,7 @@ pub(crate) fn vector_encode<P>(
     mut c: impl AsMut<[u8]>,
 ) -> Result<bool, EncodeError>
 where
-    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
+    P: KemParams + FipsByteArraySize + KemeleonByteArraySize,
 {
     let dst = c.as_mut();
     if dst.len() < P::T_HAT_LEN::USIZE {
@@ -63,7 +63,7 @@ pub(crate) fn vector_decode<P>(
     mut p: impl AsMut<[u16]>,
 ) -> Result<(), EncodeError>
 where
-    P: KemCore + EncodingSize,
+    P: KemParams + EncodingSize,
 {
     if c.as_ref().len() < P::T_HAT_LEN::USIZE {
         return Err(EncodeError::invalid_ctxt_len(c.as_ref().len()));

--- a/src/kemeleon.rs
+++ b/src/kemeleon.rs
@@ -13,7 +13,7 @@ use crate::{EncodeError, EncodingSize, FieldElement, Obfuscated};
 use core::cmp::min;
 
 use hybrid_array::typenum::Unsigned;
-use ml_kem::KemParams;
+use ml_kem::kem::Params as KemParams;
 use num_bigint::BigUint;
 
 mod ciphertext;

--- a/src/kemeleon/ciphertext.rs
+++ b/src/kemeleon/ciphertext.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use hybrid_array::ArraySize;
-use ml_kem::{kem::Kem, KemParams};
+use ml_kem::kem::{Kem, Params as KemParams};
 use rand::{CryptoRng, RngCore};
 use rand_core::CryptoRngCore;
 use sha2::Sha256;

--- a/src/kemeleon/ciphertext.rs
+++ b/src/kemeleon/ciphertext.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use hybrid_array::ArraySize;
-use ml_kem::KemCore;
+use ml_kem::{kem::Kem, KemParams};
 use rand::{CryptoRng, RngCore};
 use rand_core::CryptoRngCore;
 use sha2::Sha256;
@@ -57,11 +57,11 @@ const HKDF_INFO: [u8; 40] = *b"kemeleon ct hkdf random number generator";
 
 impl<P> Ciphertext<P>
 where
-    P: KemCore + FipsByteArraySize + KemeleonByteArraySize,
+    P: KemParams + FipsByteArraySize + KemeleonByteArraySize,
 {
     pub(crate) fn new(
-        fips_ct: &ml_kem::Ciphertext<P>,
-        ss: &ml_kem::SharedKey<P>,
+        fips_ct: &ml_kem::Ciphertext<Kem<P>>,
+        ss: &ml_kem::SharedKey<Kem<P>>,
     ) -> Result<(bool, Self), EncodeError> {
         let mut kemeleon_ct = Self {
             bytes: ByteArr::zero::<<P as KemeleonByteArraySize>::ENCODED_CT_SIZE>(),
@@ -78,7 +78,7 @@ where
     // TODO: find a good way to expose this
     #[allow(dead_code)]
     fn new_from_rng<R: RngCore + CryptoRng>(
-        fips_ct: &ml_kem::Ciphertext<P>,
+        fips_ct: &ml_kem::Ciphertext<Kem<P>>,
         rng: &mut R,
     ) -> Result<(bool, Self), EncodeError> {
         let mut kemeleon_ct = Self {
@@ -132,8 +132,8 @@ where
 
         // ml_kem::Ciphertext = c1 || c2
         fips_ct[fips_u_len..].copy_from_slice(c2);
-        let fips =
-            ml_kem::Ciphertext::<P>::try_from(&fips_ct[..]).map_err(EncodeError::MlKemError)?;
+        let fips = ml_kem::Ciphertext::<Kem<P>>::try_from(&fips_ct[..])
+            .map_err(EncodeError::MlKemError)?;
 
         Ok(Self {
             bytes: ct_bytes,
@@ -211,11 +211,11 @@ mod test {
     };
 
     use kem::{Decapsulate, Encapsulate};
-    use ml_kem::{MlKem1024, MlKem512, MlKem768};
+    use ml_kem::{MlKem1024Params, MlKem512Params, MlKem768Params};
 
     fn encode_decode_trial<P>(desc: &str)
     where
-        P: ml_kem::KemCore + FipsByteArraySize + KemeleonByteArraySize,
+        P: KemParams + FipsByteArraySize + KemeleonByteArraySize,
     {
         let mut rng = rand::thread_rng();
         // use Kemx::generate so that we don't have to worry about the
@@ -267,8 +267,8 @@ mod test {
 
     #[test]
     fn encode_decode_ct() {
-        encode_decode_trial::<MlKem512>("MlKem512 Du:10, Dv:4");
-        encode_decode_trial::<MlKem768>("MlKem768 Du:10, Dv:4");
-        encode_decode_trial::<MlKem1024>("MlKem1024 Du:11, Dv:5");
+        encode_decode_trial::<MlKem512Params>("MlKem512 Du:10, Dv:4");
+        encode_decode_trial::<MlKem768Params>("MlKem768 Du:10, Dv:4");
+        encode_decode_trial::<MlKem1024Params>("MlKem1024 Du:11, Dv:5");
     }
 }

--- a/src/kemeleon/ciphertext/precomputed.rs
+++ b/src/kemeleon/ciphertext/precomputed.rs
@@ -3103,7 +3103,7 @@ mod test {
     use crate::kemeleon::ciphertext::compress::*;
     use crate::{EncodingSize, FieldElement};
 
-    use ml_kem::{MlKem1024, MlKem512, MlKem768};
+    use ml_kem::{MlKem1024Params, MlKem512Params, MlKem768Params};
 
     fn eq_set_completeness_test(desc: &str, eq_set: &[&[u16]]) {
         let mut s = Vec::new();
@@ -3146,8 +3146,8 @@ mod test {
 
     #[test]
     fn sets_match() {
-        eq_sets_match_test::<MlKem512>("du:10, MlKem512");
-        eq_sets_match_test::<MlKem768>("du:10, MlKem768");
-        eq_sets_match_test::<MlKem1024>("du:11, MlKem1024");
+        eq_sets_match_test::<MlKem512Params>("du:10, MlKem512");
+        eq_sets_match_test::<MlKem768Params>("du:10, MlKem768");
+        eq_sets_match_test::<MlKem1024Params>("du:11, MlKem1024");
     }
 }

--- a/src/kemeleon/encapsulation_key.rs
+++ b/src/kemeleon/encapsulation_key.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use hybrid_array::{typenum::Unsigned, Array};
-use ml_kem::{EncodedSizeUser, KemParams};
+use ml_kem::{kem::Params as KemParams, EncodedSizeUser};
 
 // ========================================================================== //
 // Encapsulation Key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use hybrid_array::{
     },
     Array, ArraySize,
 };
-use ml_kem::KemParams;
+use ml_kem::kem::Params as KemParams;
 
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd)]
 pub(crate) struct FieldElement(pub u16);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use hybrid_array::{
     },
     Array, ArraySize,
 };
+use ml_kem::KemParams;
 
 #[derive(Copy, Clone, Default, PartialEq, PartialOrd)]
 pub(crate) struct FieldElement(pub u16);
@@ -246,7 +247,9 @@ impl<T: KemeleonEncodingSize> KemeleonByteArraySize for T {
 //                          Implementation
 // ========================================================================== //
 
-impl EncodingSize for ml_kem::MlKem512 {
+pub use ml_kem::{MlKem1024Params, MlKem512Params, MlKem768Params};
+
+impl EncodingSize for MlKem512Params {
     type USIZE = U12;
     type K = U2;
     type DU = U10;
@@ -256,7 +259,7 @@ impl EncodingSize for ml_kem::MlKem512 {
     const MSB_BITMASK: u8 = 0b1100_0000;
 }
 
-impl EncodingSize for ml_kem::MlKem768 {
+impl EncodingSize for MlKem768Params {
     type USIZE = U12;
     type K = U3;
     type DU = U10;
@@ -266,7 +269,7 @@ impl EncodingSize for ml_kem::MlKem768 {
     const MSB_BITMASK: u8 = 0b1111_1100;
 }
 
-impl EncodingSize for ml_kem::MlKem1024 {
+impl EncodingSize for MlKem1024Params {
     type USIZE = U12;
     type K = U4;
     type DU = U11;
@@ -281,20 +284,20 @@ impl EncodingSize for ml_kem::MlKem1024 {
 // ========================================================================== //
 
 /// ML-KEM with the parameter set for security category 1, corresponding to key search on a block cipher with a 128-bit key.
-pub type MlKem512 = mlkem::Kemx<ml_kem::MlKem512>;
+pub type MlKem512 = mlkem::Kemx<ml_kem::MlKem512Params>;
 
 /// ML-KEM with the parameter set for security category 3, corresponding to key search on a block cipher with a 192-bit key.
-pub type MlKem768 = mlkem::Kemx<ml_kem::MlKem768>;
+pub type MlKem768 = mlkem::Kemx<ml_kem::MlKem768Params>;
 
 /// ML-KEM with the parameter set for security category 5, corresponding to key search on a block cipher with a 256-bit key.
-pub type MlKem1024 = mlkem::Kemx<ml_kem::MlKem1024>;
+pub type MlKem1024 = mlkem::Kemx<ml_kem::MlKem1024Params>;
 
 impl<P> EncodingSize for mlkem::Kemx<P>
 where
-    P: ml_kem::KemCore + EncodingSize,
+    P: KemParams + EncodingSize,
 {
     type USIZE = P::USIZE;
-    type K = P::K;
+    type K = <P as EncodingSize>::K;
     type DU = P::DU;
     type DV = P::DV;
 

--- a/src/mlkem.rs
+++ b/src/mlkem.rs
@@ -8,8 +8,8 @@ use core::{fmt::Debug, marker::PhantomData};
 use hybrid_array::{typenum::Unsigned, Array};
 use kem::{Decapsulate, Encapsulate};
 use ml_kem::{
-    kem::{DecapsulationKey, EncapsulationKey, Kem},
-    Ciphertext, Encoded, EncodedSizeUser, KemCore, KemParams, SharedKey,
+    kem::{DecapsulationKey, EncapsulationKey, Kem, Params as KemParams},
+    Ciphertext, Encoded, EncodedSizeUser, KemCore, SharedKey,
 };
 use rand::RngCore;
 use rand_core::CryptoRngCore;


### PR DESCRIPTION
Instead of using `KemCore` and then wrapping `<P as KemCore>::EncapsulationKey` and  `<P as KemCore>::DecapsulationKey` this PR uses  the KemParams trait ( from a fork of the KEMs library) so that  we can instead wrap `kem::EncapsulationKey<P>` and `kem::DecapsulationKey<P>`.

One direct benefit is that this allows us to use `DecapsulationKey.encapsulation_key()` which we don't have access to when using `<P as KemCore>::DecapsulationKey`.